### PR TITLE
fix(cluster): graceful SIGINT handling and robust cleanup

### DIFF
--- a/cmd/sind/create.go
+++ b/cmd/sind/create.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/GSI-HPC/sind/pkg/cluster"
 	"github.com/GSI-HPC/sind/pkg/config"
+	sindlog "github.com/GSI-HPC/sind/pkg/log"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -85,6 +87,14 @@ func runCreateCluster(cmd *cobra.Command, name, configFile string) error {
 	meshMgr := meshMgrFrom(ctx, client, realm)
 	meshMgr.Pull = pull
 	if err := meshMgr.EnsureMesh(ctx); err != nil {
+		if meshMgr.Created() {
+			log := sindlog.From(ctx)
+			log.ErrorContext(ctx, "cleaning up partial resources, please wait")
+			cleanupCtx := context.WithoutCancel(ctx)
+			if cleanupErr := meshMgr.CleanupMesh(cleanupCtx); cleanupErr != nil {
+				log.ErrorContext(ctx, "mesh cleanup failed", "error", cleanupErr)
+			}
+		}
 		return fmt.Errorf("setting up mesh: %w", err)
 	}
 

--- a/cmd/sind/main.go
+++ b/cmd/sind/main.go
@@ -5,17 +5,24 @@ package main
 import (
 	"context"
 	"os"
+	"os/signal"
 
 	sindlog "github.com/GSI-HPC/sind/pkg/log"
 )
 
 func main() {
+	// Catch SIGINT so the process shuts down gracefully, giving deferred
+	// cleanup functions (e.g. Create rollback) a chance to run. A second
+	// SIGINT terminates immediately.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
 	cmd := NewRootCommand()
 
 	// Seed context with an error-level logger so errors are visible even
 	// when PersistentPreRunE doesn't run (e.g., unknown flag, help).
 	// PersistentPreRunE upgrades this based on the -v flag count.
-	cmd.SetContext(sindlog.With(context.Background(), newLogger(os.Stderr, 0)))
+	cmd.SetContext(sindlog.With(ctx, newLogger(os.Stderr, 0)))
 
 	if err := cmd.Execute(); err != nil {
 		sindlog.From(cmd.Context()).ErrorContext(cmd.Context(), err.Error())

--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -60,6 +60,31 @@ func Create(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager, c
 
 	log.InfoContext(ctx, "creating cluster", "name", cfg.Name, "nodes", len(cfg.Nodes))
 
+	// Register cleanup before any fallible operation. Mesh cleanup runs
+	// whenever this invocation created the mesh. Cluster resource cleanup
+	// runs only after createResources starts. WithoutCancel keeps the
+	// cleanup running when the parent context is cancelled (e.g. Ctrl+C).
+	resourcesCreated := false
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		log.ErrorContext(ctx, "cleaning up partial resources, please wait")
+		cleanupCtx := context.WithoutCancel(ctx)
+		if resourcesCreated {
+			log.DebugContext(ctx, "removing cluster resources", "name", cfg.Name)
+			if err := deleteClusterResources(cleanupCtx, client, meshMgr, cfg.Name); err != nil {
+				log.ErrorContext(ctx, "cleanup failed", "error", err)
+			}
+		}
+		if meshMgr.Created() {
+			log.DebugContext(ctx, "removing mesh created by this invocation")
+			if err := meshMgr.CleanupMesh(cleanupCtx); err != nil {
+				log.ErrorContext(ctx, "mesh cleanup failed", "error", err)
+			}
+		}
+	}()
+
 	if err := PreflightCheck(ctx, client, realm, cfg); err != nil {
 		return nil, err
 	}
@@ -71,27 +96,7 @@ func Create(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager, c
 	}
 	log.InfoContext(ctx, "resolved infrastructure", "slurm", slurmVersion)
 
-	// From this point on, Docker resources may exist. Clean them up on failure
-	// so the user does not have to run "sind delete cluster" manually before
-	// retrying. WithoutCancel keeps the cleanup running when the parent context
-	// is cancelled (e.g. Ctrl+C).
-	needsCleanup := true
-	defer func() {
-		if retErr != nil && needsCleanup {
-			log.InfoContext(ctx, "cleaning up after failed create", "name", cfg.Name)
-			cleanupCtx := context.WithoutCancel(ctx)
-			if err := deleteClusterResources(cleanupCtx, client, meshMgr, cfg.Name); err != nil {
-				log.ErrorContext(ctx, "cleanup failed", "error", err)
-			}
-			if meshMgr.Created() {
-				log.InfoContext(ctx, "cleaning up mesh created by this invocation")
-				if err := meshMgr.CleanupMesh(cleanupCtx); err != nil {
-					log.ErrorContext(ctx, "mesh cleanup failed", "error", err)
-				}
-			}
-		}
-	}()
-
+	resourcesCreated = true
 	if err := createResources(ctx, client, realm, cfg); err != nil {
 		return nil, err
 	}
@@ -125,7 +130,6 @@ func Create(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager, c
 	}
 	log.InfoContext(ctx, "slurm services enabled")
 
-	needsCleanup = false
 	return cluster, nil
 }
 

--- a/pkg/cluster/create_test.go
+++ b/pkg/cluster/create_test.go
@@ -229,7 +229,7 @@ func TestWriteClusterConfig(t *testing.T) {
 	assert.Contains(t, m.Calls[1].Args[len(m.Calls[1].Args)-1], "sind-dev-config-helper:/etc/slurm")
 
 	// RemoveContainer cleans up
-	assert.Equal(t, []string{"rm", "sind-dev-config-helper"}, m.Calls[2].Args)
+	assert.Equal(t, []string{"rm", "-f", "sind-dev-config-helper"}, m.Calls[2].Args)
 }
 
 func TestWriteClusterConfig_Pull(t *testing.T) {
@@ -797,9 +797,6 @@ func happyOnCall(t *testing.T, exitErr *exec.ExitError, override func(args []str
 			return cmdexec.MockResult{Stdout: ""}
 		}
 		// Cleanup: resource removal (best-effort during rollback)
-		if args[0] == "stop" {
-			return cmdexec.MockResult{}
-		}
 		if args[0] == "network" && args[1] == "disconnect" {
 			return cmdexec.MockResult{}
 		}
@@ -1236,8 +1233,9 @@ func TestCreate_NoCleanupOnPreflightFailure(t *testing.T) {
 	}
 }
 
-func TestCreate_NoCleanupOnResolveInfraFailure(t *testing.T) {
-	// When resolveInfra fails (before resource creation), cleanup should NOT run.
+func TestCreate_NoClusterCleanupOnResolveInfraFailure(t *testing.T) {
+	// When resolveInfra fails, cluster resource cleanup should NOT run
+	// (no "docker ps" call), but mesh cleanup should run if freshly created.
 	exitErr := notFoundErr(t)
 	var m cmdexec.MockExecutor
 	m.OnCall = happyOnCall(t, exitErr, func(args []string, _ string) (cmdexec.MockResult, bool) {
@@ -1255,9 +1253,38 @@ func TestCreate_NoCleanupOnResolveInfraFailure(t *testing.T) {
 	require.Error(t, err)
 	for _, call := range m.Calls {
 		if len(call.Args) > 0 && call.Args[0] == "ps" {
-			t.Fatal("cleanup should not run when resolveInfra fails")
+			t.Fatal("cluster cleanup should not run when resolveInfra fails")
 		}
 	}
+}
+
+func TestCreate_MeshCleanupOnResolveInfraFailure(t *testing.T) {
+	// When resolveInfra fails and mesh was freshly created, mesh should be cleaned up.
+	exitErr := notFoundErr(t)
+	var m cmdexec.MockExecutor
+	m.OnCall = happyOnCall(t, exitErr, func(args []string, _ string) (cmdexec.MockResult, bool) {
+		if args[0] == "inspect" && args[1] == "sind-dns" {
+			return cmdexec.MockResult{Err: fmt.Errorf("container not running")}, true
+		}
+		return cmdexec.MockResult{}, false
+	})
+
+	client := docker.NewClient(&m)
+	meshMgr := mesh.NewManager(client, mesh.DefaultRealm)
+	_ = meshMgr.EnsureMeshNetwork(t.Context())
+	require.True(t, meshMgr.Created())
+
+	_, err := Create(t.Context(), client, meshMgr, createCfg(), time.Millisecond)
+
+	require.Error(t, err)
+	// Mesh cleanup should run: ContainerExists (container inspect) for mesh containers.
+	var meshInspects int
+	for _, call := range m.Calls {
+		if len(call.Args) >= 2 && call.Args[0] == "container" && call.Args[1] == "inspect" {
+			meshInspects++
+		}
+	}
+	assert.GreaterOrEqual(t, meshInspects, 1, "mesh cleanup should run on resolveInfra failure")
 }
 
 func TestCreate_UnmanagedComputeSkipsSlurm(t *testing.T) {

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -85,21 +85,20 @@ func deleteClusterResources(ctx context.Context, client *docker.Client, meshMgr 
 		return err
 	}
 
-	log.DebugContext(ctx, "deleting containers", "count", len(res.Containers))
+	log.DebugContext(ctx, "removing containers", "count", len(res.Containers))
 	if err := DeleteContainers(ctx, client, res.Containers); err != nil {
 		return err
 	}
 
 	if res.NetworkExists {
-		// Disconnect SSH relay from cluster network before removing it.
 		_ = client.DisconnectNetwork(ctx, res.Network, meshMgr.SSHContainerName())
-		log.DebugContext(ctx, "deleting network", "name", string(res.Network))
+		log.DebugContext(ctx, "removing network", "name", string(res.Network))
 		if err := DeleteNetwork(ctx, client, res.Network); err != nil {
 			return err
 		}
 	}
 
-	log.DebugContext(ctx, "deleting volumes", "count", len(res.Volumes))
+	log.DebugContext(ctx, "removing volumes", "count", len(res.Volumes))
 	if err := DeleteVolumes(ctx, client, res.Volumes); err != nil {
 		return err
 	}
@@ -152,11 +151,9 @@ func ListClusterResources(ctx context.Context, client *docker.Client, realm, clu
 	return res, nil
 }
 
-// DeleteContainers stops and removes the given containers. Stop errors are
-// ignored (the container may already be stopped), but remove errors are fatal.
+// DeleteContainers force-removes the given containers (docker rm -f).
 func DeleteContainers(ctx context.Context, client *docker.Client, containers []docker.ContainerListEntry) error {
 	for _, c := range containers {
-		_ = client.StopContainer(ctx, c.Name) // best-effort
 		if err := client.RemoveContainer(ctx, c.Name); err != nil {
 			return fmt.Errorf("removing container %s: %w", c.Name, err)
 		}

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -139,12 +139,8 @@ func TestListClusterResources_LabelFilter(t *testing.T) {
 
 func TestDeleteContainers(t *testing.T) {
 	var m cmdexec.MockExecutor
-	// Container 1: stop + rm
-	m.AddResult("", "", nil) // stop
-	m.AddResult("", "", nil) // rm
-	// Container 2: stop + rm
-	m.AddResult("", "", nil) // stop
-	m.AddResult("", "", nil) // rm
+	m.AddResult("", "", nil) // rm -f container 1
+	m.AddResult("", "", nil) // rm -f container 2
 	c := docker.NewClient(&m)
 
 	containers := []docker.ContainerListEntry{
@@ -154,33 +150,14 @@ func TestDeleteContainers(t *testing.T) {
 	err := DeleteContainers(t.Context(), c, containers)
 
 	require.NoError(t, err)
-	require.Len(t, m.Calls, 4)
-	assert.Equal(t, []string{"stop", "sind-dev-controller"}, m.Calls[0].Args)
-	assert.Equal(t, []string{"rm", "sind-dev-controller"}, m.Calls[1].Args)
-	assert.Equal(t, []string{"stop", "sind-dev-worker-0"}, m.Calls[2].Args)
-	assert.Equal(t, []string{"rm", "sind-dev-worker-0"}, m.Calls[3].Args)
-}
-
-func TestDeleteContainers_StopErrorIgnored(t *testing.T) {
-	var m cmdexec.MockExecutor
-	// stop fails (already stopped) but rm succeeds
-	m.AddResult("", "Error\n", fmt.Errorf("container already stopped"))
-	m.AddResult("", "", nil) // rm
-	c := docker.NewClient(&m)
-
-	containers := []docker.ContainerListEntry{
-		{Name: "sind-dev-controller"},
-	}
-	err := DeleteContainers(t.Context(), c, containers)
-
-	require.NoError(t, err)
-	assert.Len(t, m.Calls, 2)
+	require.Len(t, m.Calls, 2)
+	assert.Equal(t, []string{"rm", "-f", "sind-dev-controller"}, m.Calls[0].Args)
+	assert.Equal(t, []string{"rm", "-f", "sind-dev-worker-0"}, m.Calls[1].Args)
 }
 
 func TestDeleteContainers_RemoveError(t *testing.T) {
 	var m cmdexec.MockExecutor
-	m.AddResult("", "", nil)                            // stop
-	m.AddResult("", "", fmt.Errorf("container in use")) // rm fails
+	m.AddResult("", "", fmt.Errorf("container in use")) // rm -f fails
 	c := docker.NewClient(&m)
 
 	containers := []docker.ContainerListEntry{
@@ -646,7 +623,8 @@ func TestDelete_CleanupMeshError(t *testing.T) {
 		volumes:       []string{"config"},
 		otherClusters: false,
 	})
-	// Override: make CleanupMesh's ContainerExists (container inspect sind-ssh) fail.
+	// Override: make CleanupMesh's ContainerExists (container inspect) fail.
+	// The first container inspect in CleanupMesh is for the keygen container.
 	inner := m.OnCall
 	m.OnCall = func(args []string, stdin string) cmdexec.MockResult {
 		if args[0] == "container" && len(args) >= 3 && args[1] == "inspect" {
@@ -660,7 +638,7 @@ func TestDelete_CleanupMeshError(t *testing.T) {
 	err := Delete(t.Context(), c, mgr, "dev")
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "removing SSH container")
+	assert.Contains(t, err.Error(), "removing SSH keygen container")
 }
 
 // --- DiscoverClusterNames ---
@@ -892,8 +870,8 @@ func deleteOnCall(t *testing.T, exitErr *exec.ExitError, clusterName string, opt
 			}
 			return cmdexec.MockResult{}
 
-		// docker stop (DeleteContainers - best effort)
-		case args[0] == "stop":
+		// docker kill (DeleteContainers - best effort)
+		case args[0] == "kill":
 			return cmdexec.MockResult{}
 
 		// docker rm (DeleteContainers or CleanupMesh)

--- a/pkg/cluster/worker.go
+++ b/pkg/cluster/worker.go
@@ -131,7 +131,7 @@ func WorkerAdd(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager
 	needsCleanup := true
 	defer func() {
 		if retErr != nil && needsCleanup {
-			log.InfoContext(ctx, "cleaning up after failed worker add", "cluster", opts.ClusterName)
+			log.ErrorContext(ctx, "cleaning up partial resources, please wait")
 			cleanupCtx := context.WithoutCancel(ctx)
 			cleanupWorkers(cleanupCtx, client, meshMgr, realm, opts.ClusterName, nodeConfigs)
 		}
@@ -401,7 +401,6 @@ func cleanupWorkers(ctx context.Context, client *docker.Client, meshMgr *mesh.Ma
 		if err := meshMgr.RemoveKnownHost(ctx, dnsName); err != nil {
 			log.DebugContext(ctx, "cleanup: removing known host", "node", nc.ShortName, "error", err)
 		}
-		_ = client.StopContainer(ctx, containerName)
 		if err := client.RemoveContainer(ctx, containerName); err != nil {
 			log.DebugContext(ctx, "cleanup: removing container", "node", nc.ShortName, "error", err)
 		}

--- a/pkg/cluster/worker_test.go
+++ b/pkg/cluster/worker_test.go
@@ -372,10 +372,6 @@ func workerAddOnCall(t *testing.T) func([]string, string) cmdexec.MockResult {
 		case args[0] == "kill":
 			return cmdexec.MockResult{}
 
-		// StopContainer (cleanup)
-		case args[0] == "stop":
-			return cmdexec.MockResult{}
-
 		// RemoveContainer (helper cleanup or worker cleanup)
 		case args[0] == "rm":
 			return cmdexec.MockResult{}
@@ -589,9 +585,11 @@ func workerRemoveOnCall(t *testing.T, nodesConf string) func([]string, string) c
 		case args[0] == "exec" && args[1] == "-i":
 			return cmdexec.MockResult{}
 
-		// Stop + remove containers
-		case args[0] == "stop":
+		// Start (DNS reload after kill)
+		case args[0] == "start":
 			return cmdexec.MockResult{}
+
+		// RemoveContainer (rm -f)
 		case args[0] == "rm":
 			return cmdexec.MockResult{}
 		}
@@ -617,7 +615,7 @@ func TestWorkerRemove_Managed(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify key operations.
-	var scontrolCalled, containerStopped, containerRemoved bool
+	var scontrolCalled, containerRemoved bool
 	var writeStdin string
 	for _, call := range m.Calls {
 		args := call.Args
@@ -628,16 +626,12 @@ func TestWorkerRemove_Managed(t *testing.T) {
 		if args[0] == "exec" && args[1] == "sind-dev-controller" && len(args) > 2 && args[2] == "scontrol" {
 			scontrolCalled = true
 		}
-		if args[0] == "stop" && strings.Contains(joined, "worker-1") {
-			containerStopped = true
-		}
 		if args[0] == "rm" && strings.Contains(joined, "worker-1") {
 			containerRemoved = true
 		}
 	}
 
 	assert.True(t, scontrolCalled, "scontrol reconfigure should be called")
-	assert.True(t, containerStopped, "container should be stopped")
 	assert.True(t, containerRemoved, "container should be removed")
 	assert.Contains(t, writeStdin, "worker-0", "updated conf should still have worker-0")
 	assert.NotContains(t, writeStdin, "worker-1", "updated conf should not have worker-1")
@@ -681,18 +675,14 @@ func TestWorkerRemove_Unmanaged(t *testing.T) {
 		}
 	}
 
-	// Verify container was still stopped and removed.
-	var stopped, removed bool
+	// Verify container was removed (rm -f handles kill internally).
+	var removed bool
 	for _, call := range m.Calls {
 		joined := strings.Join(call.Args, " ")
-		if call.Args[0] == "stop" && strings.Contains(joined, "worker-1") {
-			stopped = true
-		}
 		if call.Args[0] == "rm" && strings.Contains(joined, "worker-1") {
 			removed = true
 		}
 	}
-	assert.True(t, stopped, "container should be stopped")
 	assert.True(t, removed, "container should be removed")
 }
 
@@ -847,18 +837,14 @@ func TestWorkerRemove_MultipleNodes(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// Verify both containers were stopped and removed.
-	var stopped, removed int
+	// Verify both worker containers were removed (rm -f handles kill internally).
+	var removeCount int
 	for _, call := range m.Calls {
-		if call.Args[0] == "stop" {
-			stopped++
-		}
-		if call.Args[0] == "rm" {
-			removed++
+		if call.Args[0] == "rm" && len(call.Args) >= 2 && strings.HasPrefix(call.Args[len(call.Args)-1], "sind-dev-worker-") {
+			removeCount++
 		}
 	}
-	assert.Equal(t, 2, stopped, "both containers should be stopped")
-	assert.Equal(t, 2, removed, "both containers should be removed")
+	assert.Equal(t, 2, removeCount, "both containers should be removed")
 }
 
 func TestWorkerRemove_ListContainersError(t *testing.T) {
@@ -978,8 +964,6 @@ func TestWorkerRemove_NoController(t *testing.T) {
 		case args[0] == "exec" && args[1] == "sind-ssh":
 			return cmdexec.MockResult{Stdout: "worker-0.dev.sind.sind ssh-ed25519 AAAA\n"}
 		case args[0] == "exec" && args[1] == "-i":
-			return cmdexec.MockResult{}
-		case args[0] == "stop":
 			return cmdexec.MockResult{}
 		case args[0] == "rm":
 			return cmdexec.MockResult{}
@@ -1269,14 +1253,14 @@ func TestWorkerAdd_CleansUpOnFailure(t *testing.T) {
 	}, time.Millisecond)
 
 	require.Error(t, err)
-	// Verify cleanup ran: look for "docker stop" call on the new worker.
-	var stopCalls int
+	// Verify cleanup ran: look for "docker rm -f" on the new worker container.
+	var removed bool
 	for _, call := range m.Calls {
-		if len(call.Args) > 0 && call.Args[0] == "stop" {
-			stopCalls++
+		if call.Args[0] == "rm" && len(call.Args) >= 2 && strings.HasPrefix(call.Args[len(call.Args)-1], "sind-dev-worker-") {
+			removed = true
 		}
 	}
-	assert.Equal(t, 1, stopCalls, "cleanup should stop the new worker container")
+	assert.True(t, removed, "cleanup should remove the new worker container")
 }
 
 func TestWorkerAdd_NoCleanupOnValidationFailure(t *testing.T) {
@@ -1297,9 +1281,9 @@ func TestWorkerAdd_NoCleanupOnValidationFailure(t *testing.T) {
 	}, time.Millisecond)
 
 	require.Error(t, err)
-	// No "docker stop" calls → cleanup did not run.
+	// No "docker rm" calls on worker containers → cleanup did not run.
 	for _, call := range m.Calls {
-		if len(call.Args) > 0 && call.Args[0] == "stop" {
+		if call.Args[0] == "rm" && len(call.Args) >= 2 && strings.HasPrefix(call.Args[len(call.Args)-1], "sind-dev-worker-") {
 			t.Fatal("cleanup should not run when validation fails")
 		}
 	}
@@ -1545,9 +1529,6 @@ func workerLifecycleOnCall(t *testing.T) func([]string, string) cmdexec.MockResu
 		case args[0] == "kill":
 			return cmdexec.MockResult{}
 
-		case args[0] == "stop":
-			return cmdexec.MockResult{}
-
 		case args[0] == "rm":
 			return cmdexec.MockResult{}
 		}
@@ -1586,21 +1567,17 @@ func TestWorkerAddRemoveLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify both add and remove operations happened.
-	var created, stopped, removed bool
+	var created, removed bool
 	for _, call := range m.Calls {
 		args := call.Args
 		joined := strings.Join(args, " ")
 		if args[0] == "create" && strings.Contains(joined, "sind-dev-worker-1") {
 			created = true
 		}
-		if args[0] == "stop" && strings.Contains(joined, "worker-1") {
-			stopped = true
-		}
 		if args[0] == "rm" && strings.Contains(joined, "worker-1") {
 			removed = true
 		}
 	}
 	assert.True(t, created, "worker-1 should be created during add")
-	assert.True(t, stopped, "worker-1 should be stopped during remove")
 	assert.True(t, removed, "worker-1 should be removed during remove")
 }

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -53,9 +53,10 @@ func (c *Client) StopContainer(ctx context.Context, name ContainerName) error {
 	return err
 }
 
-// RemoveContainer removes a container.
+// RemoveContainer force-removes a container. If the container is running it
+// is killed first. This is equivalent to docker rm -f.
 func (c *Client) RemoveContainer(ctx context.Context, name ContainerName) error {
-	_, _, err := c.run(ctx, "rm", string(name))
+	_, _, err := c.run(ctx, "rm", "-f", string(name))
 	return err
 }
 

--- a/pkg/docker/container_test.go
+++ b/pkg/docker/container_test.go
@@ -294,7 +294,7 @@ func TestRemoveContainer(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, m.Calls, 1)
-	assert.Equal(t, []string{"rm", string(testContainerName)}, m.Calls[0].Args)
+	assert.Equal(t, []string{"rm", "-f", string(testContainerName)}, m.Calls[0].Args)
 }
 
 func TestRemoveContainer_Error(t *testing.T) {

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -149,6 +149,11 @@ func (m *Manager) CleanupMesh(ctx context.Context) error {
 	}
 
 	// Remove containers first (auto-disconnects from networks).
+	// Include the keygen container which may be orphaned if a previous
+	// EnsureSSHVolume was interrupted.
+	if err := m.removeContainerIfExists(ctx, m.SSHKeygenName()); err != nil {
+		return fmt.Errorf("removing SSH keygen container: %w", err)
+	}
 	if err := m.removeContainerIfExists(ctx, m.SSHContainerName()); err != nil {
 		return fmt.Errorf("removing SSH container: %w", err)
 	}
@@ -176,7 +181,6 @@ func (m *Manager) removeContainerIfExists(ctx context.Context, name docker.Conta
 	if !exists {
 		return nil
 	}
-	_ = m.Docker.StopContainer(ctx, name) // best-effort; may already be stopped
 	return m.Docker.RemoveContainer(ctx, name)
 }
 

--- a/pkg/mesh/mesh_test.go
+++ b/pkg/mesh/mesh_test.go
@@ -68,17 +68,16 @@ func TestMeshLifecycle(t *testing.T) {
 		rec.AddResult("[{}]\n", "", nil) // SSH vol
 		rec.AddResult("[{}]\n", "", nil) // SSH
 
-		// CleanupMesh: remove SSH, DNS, network, volume
-		rec.AddResult("[{}]\n", "", nil)            // SSH exists
-		rec.AddResult("sind-ssh\n", "", nil)        // stop SSH
-		rec.AddResult("sind-ssh\n", "", nil)        // rm SSH
-		rec.AddResult("[{}]\n", "", nil)            // DNS exists
-		rec.AddResult("sind-dns\n", "", nil)        // stop DNS
-		rec.AddResult("sind-dns\n", "", nil)        // rm DNS
-		rec.AddResult("[{}]\n", "", nil)            // network exists
-		rec.AddResult("sind-mesh\n", "", nil)       // rm network
-		rec.AddResult("[{}]\n", "", nil)            // SSH vol exists
-		rec.AddResult("sind-ssh-config\n", "", nil) // rm SSH vol
+		// CleanupMesh: remove keygen (gone), SSH, DNS, network, volume
+		rec.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)}) // keygen exists → no
+		rec.AddResult("[{}]\n", "", nil)                                          // SSH exists
+		rec.AddResult("sind-ssh\n", "", nil)                                      // rm -f SSH
+		rec.AddResult("[{}]\n", "", nil)                                          // DNS exists
+		rec.AddResult("sind-dns\n", "", nil)                                      // rm -f DNS
+		rec.AddResult("[{}]\n", "", nil)                                          // network exists
+		rec.AddResult("sind-mesh\n", "", nil)                                     // rm network
+		rec.AddResult("[{}]\n", "", nil)                                          // SSH vol exists
+		rec.AddResult("sind-ssh-config\n", "", nil)                               // rm SSH vol
 
 		// Verify: all gone
 		rec.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)}) // network
@@ -176,16 +175,15 @@ func TestDNSRecordLifecycle(t *testing.T) {
 		rec.AddResult("sind-dns\n", "", nil)
 
 		// CleanupMesh
-		rec.AddResult("[{}]\n", "", nil)            // SSH exists
-		rec.AddResult("sind-ssh\n", "", nil)        // stop SSH
-		rec.AddResult("sind-ssh\n", "", nil)        // rm SSH
-		rec.AddResult("[{}]\n", "", nil)            // DNS exists
-		rec.AddResult("sind-dns\n", "", nil)        // stop DNS
-		rec.AddResult("sind-dns\n", "", nil)        // rm DNS
-		rec.AddResult("[{}]\n", "", nil)            // network exists
-		rec.AddResult("sind-mesh\n", "", nil)       // rm network
-		rec.AddResult("[{}]\n", "", nil)            // SSH vol exists
-		rec.AddResult("sind-ssh-config\n", "", nil) // rm SSH vol
+		rec.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)}) // keygen exists → no
+		rec.AddResult("[{}]\n", "", nil)                                          // SSH exists
+		rec.AddResult("sind-ssh\n", "", nil)                                      // rm -f SSH
+		rec.AddResult("[{}]\n", "", nil)                                          // DNS exists
+		rec.AddResult("sind-dns\n", "", nil)                                      // rm -f DNS
+		rec.AddResult("[{}]\n", "", nil)                                          // network exists
+		rec.AddResult("sind-mesh\n", "", nil)                                     // rm network
+		rec.AddResult("[{}]\n", "", nil)                                          // SSH vol exists
+		rec.AddResult("sind-ssh-config\n", "", nil)                               // rm SSH vol
 	}
 	t.Cleanup(func() { _ = mgr.CleanupMesh(context.Background()) })
 
@@ -311,13 +309,13 @@ func TestEnsureMesh_SSHContainerError(t *testing.T) {
 
 func TestCleanupMesh(t *testing.T) {
 	var m cmdexec.MockExecutor
-	// removeContainerIfExists(SSH): exists, stop, remove
+	// removeContainerIfExists(keygen): not found
+	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)})
+	// removeContainerIfExists(SSH): exists, rm -f
 	m.AddResult("[{}]\n", "", nil)
 	m.AddResult("sind-ssh\n", "", nil)
-	m.AddResult("sind-ssh\n", "", nil)
-	// removeContainerIfExists(DNS): exists, stop, remove
+	// removeContainerIfExists(DNS): exists, rm -f
 	m.AddResult("[{}]\n", "", nil)
-	m.AddResult("sind-dns\n", "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	// removeNetworkIfExists: exists, remove
 	m.AddResult("[{}]\n", "", nil)
@@ -332,22 +330,22 @@ func TestCleanupMesh(t *testing.T) {
 	err := mgr.CleanupMesh(t.Context())
 	require.NoError(t, err)
 
-	// Verify order: SSH container, DNS container, network, volume.
-	assert.Equal(t, []string{"container", "inspect", string(SSHContainerName)}, m.Calls[0].Args)
-	assert.Equal(t, []string{"stop", string(SSHContainerName)}, m.Calls[1].Args)
-	assert.Equal(t, []string{"rm", string(SSHContainerName)}, m.Calls[2].Args)
+	// Verify order: keygen container, SSH container, DNS container, network, volume.
+	assert.Equal(t, []string{"container", "inspect", "sind-ssh-keygen"}, m.Calls[0].Args)
+	assert.Equal(t, []string{"container", "inspect", string(SSHContainerName)}, m.Calls[1].Args)
+	assert.Equal(t, []string{"rm", "-f", string(SSHContainerName)}, m.Calls[2].Args)
 	assert.Equal(t, []string{"container", "inspect", string(DNSContainerName)}, m.Calls[3].Args)
-	assert.Equal(t, []string{"stop", string(DNSContainerName)}, m.Calls[4].Args)
-	assert.Equal(t, []string{"rm", string(DNSContainerName)}, m.Calls[5].Args)
-	assert.Equal(t, []string{"network", "inspect", string(NetworkName)}, m.Calls[6].Args)
-	assert.Equal(t, []string{"network", "rm", string(NetworkName)}, m.Calls[7].Args)
-	assert.Equal(t, []string{"volume", "inspect", string(SSHVolumeName)}, m.Calls[8].Args)
-	assert.Equal(t, []string{"volume", "rm", string(SSHVolumeName)}, m.Calls[9].Args)
+	assert.Equal(t, []string{"rm", "-f", string(DNSContainerName)}, m.Calls[4].Args)
+	assert.Equal(t, []string{"network", "inspect", string(NetworkName)}, m.Calls[5].Args)
+	assert.Equal(t, []string{"network", "rm", string(NetworkName)}, m.Calls[6].Args)
+	assert.Equal(t, []string{"volume", "inspect", string(SSHVolumeName)}, m.Calls[7].Args)
+	assert.Equal(t, []string{"volume", "rm", string(SSHVolumeName)}, m.Calls[8].Args)
 }
 
 func TestCleanupMesh_NoneExist(t *testing.T) {
 	var m cmdexec.MockExecutor
-	// All four exist checks return not found.
+	// All five exist checks return not found (keygen, SSH, DNS, network, volume).
+	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)})
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)})
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)})
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)})
@@ -358,11 +356,14 @@ func TestCleanupMesh_NoneExist(t *testing.T) {
 
 	err := mgr.CleanupMesh(t.Context())
 	require.NoError(t, err)
-	assert.Len(t, m.Calls, 4) // only exist checks, no removes
+	assert.Len(t, m.Calls, 5) // only exist checks, no removes
 }
 
 func TestCleanupMesh_SSHContainerError(t *testing.T) {
 	var m cmdexec.MockExecutor
+	// keygen: not found
+	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)})
+	// SSH: connection refused
 	m.AddResult("", "", fmt.Errorf("connection refused"))
 	c := docker.NewClient(&m)
 	mgr := NewManager(c, DefaultRealm)
@@ -374,6 +375,8 @@ func TestCleanupMesh_SSHContainerError(t *testing.T) {
 
 func TestCleanupMesh_DNSContainerError(t *testing.T) {
 	var m cmdexec.MockExecutor
+	// keygen: not found
+	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)})
 	// SSH container doesn't exist
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)})
 	// DNS container check fails
@@ -388,6 +391,7 @@ func TestCleanupMesh_DNSContainerError(t *testing.T) {
 
 func TestCleanupMesh_NetworkError(t *testing.T) {
 	var m cmdexec.MockExecutor
+	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)}) // keygen
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)}) // SSH
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)}) // DNS
 	m.AddResult("", "", fmt.Errorf("connection refused"))                   // network
@@ -401,9 +405,10 @@ func TestCleanupMesh_NetworkError(t *testing.T) {
 
 func TestCleanupMesh_RemoveContainerError(t *testing.T) {
 	var m cmdexec.MockExecutor
-	// SSH container: exists, stop (best-effort), remove fails
+	// keygen: not found
+	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)})
+	// SSH container: exists, rm -f fails
 	m.AddResult("[{}]\n", "", nil)
-	m.AddResult("sind-ssh\n", "", nil)
 	m.AddResult("", "Error: removal in progress\n", fmt.Errorf("exit status 1"))
 	c := docker.NewClient(&m)
 	mgr := NewManager(c, DefaultRealm)
@@ -415,6 +420,7 @@ func TestCleanupMesh_RemoveContainerError(t *testing.T) {
 
 func TestCleanupMesh_VolumeError(t *testing.T) {
 	var m cmdexec.MockExecutor
+	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)}) // keygen
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)}) // SSH
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)}) // DNS
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)}) // network
@@ -1012,13 +1018,13 @@ func TestCustomRealm_EnsureSSH(t *testing.T) {
 
 func TestCustomRealm_CleanupMesh(t *testing.T) {
 	var m cmdexec.MockExecutor
-	// SSH container: exists, stop, remove
+	// keygen container: not found
+	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: exitCode1(t)})
+	// SSH container: exists, rm -f
 	m.AddResult("[{}]\n", "", nil)
 	m.AddResult("myrealm-ssh\n", "", nil)
-	m.AddResult("myrealm-ssh\n", "", nil)
-	// DNS container: exists, stop, remove
+	// DNS container: exists, rm -f
 	m.AddResult("[{}]\n", "", nil)
-	m.AddResult("myrealm-dns\n", "", nil)
 	m.AddResult("myrealm-dns\n", "", nil)
 	// Network: exists, remove
 	m.AddResult("[{}]\n", "", nil)
@@ -1032,16 +1038,15 @@ func TestCustomRealm_CleanupMesh(t *testing.T) {
 	err := mgr.CleanupMesh(t.Context())
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"container", "inspect", "myrealm-ssh"}, m.Calls[0].Args)
-	assert.Equal(t, []string{"stop", "myrealm-ssh"}, m.Calls[1].Args)
-	assert.Equal(t, []string{"rm", "myrealm-ssh"}, m.Calls[2].Args)
+	assert.Equal(t, []string{"container", "inspect", "myrealm-ssh-keygen"}, m.Calls[0].Args)
+	assert.Equal(t, []string{"container", "inspect", "myrealm-ssh"}, m.Calls[1].Args)
+	assert.Equal(t, []string{"rm", "-f", "myrealm-ssh"}, m.Calls[2].Args)
 	assert.Equal(t, []string{"container", "inspect", "myrealm-dns"}, m.Calls[3].Args)
-	assert.Equal(t, []string{"stop", "myrealm-dns"}, m.Calls[4].Args)
-	assert.Equal(t, []string{"rm", "myrealm-dns"}, m.Calls[5].Args)
-	assert.Equal(t, []string{"network", "inspect", "myrealm-mesh"}, m.Calls[6].Args)
-	assert.Equal(t, []string{"network", "rm", "myrealm-mesh"}, m.Calls[7].Args)
-	assert.Equal(t, []string{"volume", "inspect", "myrealm-ssh-config"}, m.Calls[8].Args)
-	assert.Equal(t, []string{"volume", "rm", "myrealm-ssh-config"}, m.Calls[9].Args)
+	assert.Equal(t, []string{"rm", "-f", "myrealm-dns"}, m.Calls[4].Args)
+	assert.Equal(t, []string{"network", "inspect", "myrealm-mesh"}, m.Calls[5].Args)
+	assert.Equal(t, []string{"network", "rm", "myrealm-mesh"}, m.Calls[6].Args)
+	assert.Equal(t, []string{"volume", "inspect", "myrealm-ssh-config"}, m.Calls[7].Args)
+	assert.Equal(t, []string{"volume", "rm", "myrealm-ssh-config"}, m.Calls[8].Args)
 }
 
 // dnsInspectJSON returns a mock docker inspect result for the DNS container on the mesh network.
@@ -1101,6 +1106,7 @@ func ensureMeshAllExist(m *cmdexec.MockExecutor) {
 
 // cleanupMeshAllGone queues mock results for CleanupMesh where no resources exist.
 func cleanupMeshAllGone(m *cmdexec.MockExecutor, ps *os.ProcessState) {
+	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: ps}) // keygen exists → no
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: ps}) // SSH exists → no
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: ps}) // DNS exists → no
 	m.AddResult("", "Error\n", &exec.ExitError{ProcessState: ps}) // network exists → no

--- a/pkg/mesh/ssh.go
+++ b/pkg/mesh/ssh.go
@@ -67,7 +67,7 @@ func (m *Manager) EnsureSSHVolume(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("creating temporary container: %w", err)
 	}
-	defer m.Docker.RemoveContainer(ctx, keygenName) //nolint:errcheck
+	defer m.Docker.RemoveContainer(context.WithoutCancel(ctx), keygenName) //nolint:errcheck
 
 	err = m.Docker.CopyFilesToContainer(ctx, keygenName, "/ssh", map[string]docker.File{
 		"id_ed25519":     {Content: privKeyPEM, Mode: 0600},

--- a/pkg/mesh/ssh_test.go
+++ b/pkg/mesh/ssh_test.go
@@ -125,7 +125,7 @@ func TestEnsureSSHVolume_Creates(t *testing.T) {
 		sshKeygenImage,
 	}, m.Calls[2].Args)
 	assert.Equal(t, []string{"cp", "-", keygenName + ":/ssh"}, m.Calls[3].Args)
-	assert.Equal(t, []string{"rm", keygenName}, m.Calls[4].Args)
+	assert.Equal(t, []string{"rm", "-f", keygenName}, m.Calls[4].Args)
 
 	// Verify all three files are in the tar archive.
 	privKey := extractTarFile(t, m.Calls[3].Stdin, "id_ed25519")
@@ -213,7 +213,7 @@ func TestEnsureSSHVolume_CopyError(t *testing.T) {
 	assert.Contains(t, err.Error(), "writing SSH keys")
 
 	// Verify temp container is still cleaned up on error.
-	assert.Equal(t, []string{"rm", string(mgr.SSHKeygenName())}, m.Calls[4].Args)
+	assert.Equal(t, []string{"rm", "-f", string(mgr.SSHKeygenName())}, m.Calls[4].Args)
 }
 
 func TestEnsureSSHVolume_Pull(t *testing.T) {


### PR DESCRIPTION
- Handle SIGINT via signal.NotifyContext so deferred cleanup runs
- Register cleanup defer before PreflightCheck to cover all failure
  paths including context cancellation
- Clean up mesh when EnsureMesh fails or is interrupted
- Clean up freshly created mesh on Create failure (tracked via
  Manager.Created)
- Use docker rm -f for atomic container removal instead of separate
  kill + rm
- Remove orphaned keygen containers in CleanupMesh
- Use context.WithoutCancel in EnsureSSHVolume keygen defer
- Log cleanup start at error level so it is visible without -v