### PR TITLE
test(cmd/sind): parallelize integration tests

### DIFF
--- a/cmd/sind/create_test.go
+++ b/cmd/sind/create_test.go
@@ -144,30 +144,30 @@ func TestLoadConfig_PreservesName(t *testing.T) {
 // TestClusterLifecycle exercises the full user workflow via CLI commands:
 // create cluster → get/status → power ops → add worker → delete worker → delete cluster.
 func TestClusterLifecycle(t *testing.T) {
-	t.Chdir(t.TempDir())
+	t.Parallel()
 	c := realClient(t)
 	skipIfNoNsdelegate(t)
 	image := testImage(t)
+	dataDir := t.TempDir()
 
-	t.Setenv("SIND_REALM", testRealm)
-
+	realm := "it-e2e-" + testID
 	cluster := "e2e-" + testID
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
 	defer cancel()
 
-	meshMgr := mesh.NewManager(c, testRealm)
+	meshMgr := mesh.NewManager(c, realm)
 	t.Cleanup(func() {
 		bg := context.Background()
 		// Best-effort cleanup in case test fails partway.
 		for _, name := range []string{"controller", "worker-0", "worker-1"} {
-			cn := docker.ContainerName(testRealm + "-" + cluster + "-" + name)
+			cn := docker.ContainerName(realm + "-" + cluster + "-" + name)
 			_ = c.KillContainer(bg, cn)
 			_ = c.RemoveContainer(bg, cn)
 		}
 		for _, vt := range []string{"config", "munge", "data"} {
-			_ = c.RemoveVolume(bg, docker.VolumeName(testRealm+"-"+cluster+"-"+vt))
+			_ = c.RemoveVolume(bg, docker.VolumeName(realm+"-"+cluster+"-"+vt))
 		}
-		_ = c.RemoveNetwork(bg, docker.NetworkName(testRealm+"-"+cluster+"-net"))
+		_ = c.RemoveNetwork(bg, docker.NetworkName(realm+"-"+cluster+"-net"))
 		_ = meshMgr.CleanupMesh(bg)
 	})
 
@@ -177,43 +177,43 @@ func TestClusterLifecycle(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgPath, []byte("kind: Cluster\ndefaults:\n  image: "+image+"\n"), 0o644))
 
 	// --- create cluster ---
-	_, stderr, err := executeWithDockerCtx(ctx, "create", "cluster", cluster, "--config", cfgPath)
+	_, stderr, err := executeWithRealmCtx(ctx, realm, "create", "cluster", cluster, "--config", cfgPath, "--data", dataDir)
 	require.NoError(t, err, "create cluster failed: stderr=%q", stderr)
 
 	// --- get clusters ---
 	var stdout string
-	stdout, _, err = executeWithDockerCtx(ctx, "get", "clusters")
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "get", "clusters")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, cluster)
 	assert.Contains(t, stdout, "running")
 
 	// --- get nodes ---
-	stdout, _, err = executeWithDockerCtx(ctx, "get", "nodes", cluster)
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "get", "nodes", cluster)
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "controller."+cluster)
 	assert.Contains(t, stdout, "worker-0."+cluster)
 
 	// --- get networks ---
-	stdout, _, err = executeWithDockerCtx(ctx, "get", "networks")
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "get", "networks")
 	require.NoError(t, err)
-	assert.Contains(t, stdout, testRealm+"-"+cluster+"-net")
-	assert.Contains(t, stdout, testRealm+"-mesh")
+	assert.Contains(t, stdout, realm+"-"+cluster+"-net")
+	assert.Contains(t, stdout, realm+"-mesh")
 
 	// --- get volumes ---
 	// Data volume is not created when using host-path bind mount (default).
-	stdout, _, err = executeWithDockerCtx(ctx, "get", "volumes")
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "get", "volumes")
 	require.NoError(t, err)
-	assert.Contains(t, stdout, testRealm+"-"+cluster+"-config")
-	assert.Contains(t, stdout, testRealm+"-"+cluster+"-munge")
+	assert.Contains(t, stdout, realm+"-"+cluster+"-config")
+	assert.Contains(t, stdout, realm+"-"+cluster+"-munge")
 
 	// --- get munge-key ---
-	stdout, _, err = executeWithDockerCtx(ctx, "get", "munge-key", cluster)
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "get", "munge-key", cluster)
 	require.NoError(t, err)
 	assert.NotEmpty(t, stdout)
 	assert.NotContains(t, stdout, "Error")
 
 	// --- status ---
-	stdout, _, err = executeWithDockerCtx(ctx, "status", cluster)
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "status", cluster)
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "CLUSTER")
 	assert.Contains(t, stdout, cluster)
@@ -225,83 +225,83 @@ func TestClusterLifecycle(t *testing.T) {
 	assert.Contains(t, stdout, "MOUNTS")
 
 	// --- exec ---
-	stdout, stderr, err = executeWithDockerCtx(ctx, "exec", cluster, "--", "hostname")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "exec", cluster, "--", "hostname")
 	require.NoError(t, err, "exec failed: stdout=%q stderr=%q", stdout, stderr)
 	assert.Contains(t, stdout, "controller")
 
 	// exec with default cluster
-	_, _, err = executeWithDockerCtx(ctx, "exec", "--", "echo", "hello")
+	_, _, err = executeWithRealmCtx(ctx, realm, "exec", "--", "echo", "hello")
 	if err != nil {
 		// Only fails if no "default" cluster exists — expected in isolation.
 		assert.Contains(t, err.Error(), "default")
 	}
 
 	// exec missing separator
-	_, _, err = executeWithDockerCtx(ctx, "exec", "hostname")
+	_, _, err = executeWithRealmCtx(ctx, realm, "exec", "hostname")
 	assert.Error(t, err)
 
 	// exec missing command
-	_, _, err = executeWithDockerCtx(ctx, "exec", "--")
+	_, _, err = executeWithRealmCtx(ctx, realm, "exec", "--")
 	assert.Error(t, err)
 
 	// --- power shutdown ---
 	node := "worker-0." + cluster
-	_, _, err = executeWithDockerCtx(ctx, "power", "shutdown", node)
+	_, _, err = executeWithRealmCtx(ctx, realm, "power", "shutdown", node)
 	require.NoError(t, err)
-	info, err := c.InspectContainer(ctx, docker.ContainerName(testRealm+"-"+cluster+"-worker-0"))
+	info, err := c.InspectContainer(ctx, docker.ContainerName(realm+"-"+cluster+"-worker-0"))
 	require.NoError(t, err)
 	assert.Equal(t, "exited", info.Status)
 
 	// --- power on ---
-	_, _, err = executeWithDockerCtx(ctx, "power", "on", node)
+	_, _, err = executeWithRealmCtx(ctx, realm, "power", "on", node)
 	require.NoError(t, err)
-	info, err = c.InspectContainer(ctx, docker.ContainerName(testRealm+"-"+cluster+"-worker-0"))
+	info, err = c.InspectContainer(ctx, docker.ContainerName(realm+"-"+cluster+"-worker-0"))
 	require.NoError(t, err)
 	assert.Equal(t, "running", info.Status)
 
 	// --- power freeze / unfreeze ---
-	_, _, err = executeWithDockerCtx(ctx, "power", "freeze", node)
+	_, _, err = executeWithRealmCtx(ctx, realm, "power", "freeze", node)
 	require.NoError(t, err)
-	info, _ = c.InspectContainer(ctx, docker.ContainerName(testRealm+"-"+cluster+"-worker-0"))
+	info, _ = c.InspectContainer(ctx, docker.ContainerName(realm+"-"+cluster+"-worker-0"))
 	assert.Equal(t, "paused", info.Status)
 
-	_, _, err = executeWithDockerCtx(ctx, "power", "unfreeze", node)
+	_, _, err = executeWithRealmCtx(ctx, realm, "power", "unfreeze", node)
 	require.NoError(t, err)
-	info, _ = c.InspectContainer(ctx, docker.ContainerName(testRealm+"-"+cluster+"-worker-0"))
+	info, _ = c.InspectContainer(ctx, docker.ContainerName(realm+"-"+cluster+"-worker-0"))
 	assert.Equal(t, "running", info.Status)
 
 	// --- create worker ---
-	_, stderr, err = executeWithDockerCtx(ctx, "create", "worker", cluster, "--count", "1")
+	_, stderr, err = executeWithRealmCtx(ctx, realm, "create", "worker", cluster, "--count", "1")
 	require.NoError(t, err, "create worker failed: stderr=%q", stderr)
 
 	// Verify new node appears.
-	stdout, _, err = executeWithDockerCtx(ctx, "get", "nodes", cluster)
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "get", "nodes", cluster)
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "worker-1."+cluster)
 
 	// --- delete worker ---
-	_, _, err = executeWithDockerCtx(ctx, "delete", "worker", "worker-1."+cluster)
+	_, _, err = executeWithRealmCtx(ctx, realm, "delete", "worker", "worker-1."+cluster)
 	require.NoError(t, err)
 
 	// Verify node is gone.
-	stdout, _, err = executeWithDockerCtx(ctx, "get", "nodes", cluster)
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "get", "nodes", cluster)
 	require.NoError(t, err)
 	assert.NotContains(t, stdout, "worker-1")
 
 	// --- delete cluster ---
-	_, _, err = executeWithDockerCtx(ctx, "delete", "cluster", cluster)
+	_, _, err = executeWithRealmCtx(ctx, realm, "delete", "cluster", cluster)
 	require.NoError(t, err)
 
 	// Verify everything is gone.
-	exists, err := c.ContainerExists(ctx, docker.ContainerName(testRealm+"-"+cluster+"-controller"))
+	exists, err := c.ContainerExists(ctx, docker.ContainerName(realm+"-"+cluster+"-controller"))
 	require.NoError(t, err)
 	assert.False(t, exists)
 
-	exists, err = c.NetworkExists(ctx, docker.NetworkName(testRealm+"-"+cluster+"-net"))
+	exists, err = c.NetworkExists(ctx, docker.NetworkName(realm+"-"+cluster+"-net"))
 	require.NoError(t, err)
 	assert.False(t, exists)
 
 	// --- delete nonexistent cluster (idempotent) ---
-	_, _, err = executeWithDockerCtx(ctx, "delete", "cluster", "nonexistent-"+testID)
+	_, _, err = executeWithRealmCtx(ctx, realm, "delete", "cluster", "nonexistent-"+testID)
 	require.NoError(t, err, "deleting nonexistent cluster should not error")
 }

--- a/cmd/sind/delete_test.go
+++ b/cmd/sind/delete_test.go
@@ -41,18 +41,19 @@ func TestDeleteCluster_AllRejectsArgs(t *testing.T) {
 // --- Integration ---
 
 func TestDeleteClusterLifecycle(t *testing.T) {
+	t.Parallel()
 	c := realClient(t)
 	ctx := t.Context()
-	t.Setenv("SIND_REALM", testRealm)
+	realm := "it-del-" + testID
 	cluster := "cli-del-" + testID
 
-	meshMgr := mesh.NewManager(c, testRealm)
+	meshMgr := mesh.NewManager(c, realm)
 
-	netName := docker.NetworkName(testRealm + "-" + cluster + "-net")
-	ctrName := docker.ContainerName(testRealm + "-" + cluster + "-controller")
-	volConfig := docker.VolumeName(testRealm + "-" + cluster + "-config")
-	volMunge := docker.VolumeName(testRealm + "-" + cluster + "-munge")
-	volData := docker.VolumeName(testRealm + "-" + cluster + "-data")
+	netName := docker.NetworkName(realm + "-" + cluster + "-net")
+	ctrName := docker.ContainerName(realm + "-" + cluster + "-controller")
+	volConfig := docker.VolumeName(realm + "-" + cluster + "-config")
+	volMunge := docker.VolumeName(realm + "-" + cluster + "-munge")
+	volData := docker.VolumeName(realm + "-" + cluster + "-data")
 
 	t.Cleanup(func() {
 		bg := context.Background()
@@ -77,7 +78,7 @@ func TestDeleteClusterLifecycle(t *testing.T) {
 	_, err = c.RunContainer(ctx,
 		"--name", string(ctrName),
 		"--network", string(netName),
-		"--label", "sind.realm="+testRealm,
+		"--label", "sind.realm="+realm,
 		"--label", "sind.cluster="+cluster,
 		"--label", "sind.role=controller",
 		"busybox:latest", "sleep", "120",
@@ -85,7 +86,7 @@ func TestDeleteClusterLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Delete via CLI.
-	_, _, err = executeWithDocker("delete", "cluster", cluster)
+	_, _, err = executeWithRealm(realm, "delete", "cluster", cluster)
 	require.NoError(t, err)
 
 	// Verify cluster resources are gone.

--- a/cmd/sind/get_test.go
+++ b/cmd/sind/get_test.go
@@ -209,23 +209,26 @@ func TestGetDNS_Error(t *testing.T) {
 // --- Integration ---
 
 func TestGetClustersEmpty(t *testing.T) {
+	t.Parallel()
 	realClient(t)
-	stdout, _, err := executeWithDocker("get", "clusters")
+	realm := "it-empty-" + testID
+	stdout, _, err := executeWithRealm(realm, "get", "clusters")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "NAME")
 }
 
 func TestGetLifecycle(t *testing.T) {
+	t.Parallel()
 	c := realClient(t)
 	ctx := t.Context()
-	t.Setenv("SIND_REALM", testRealm)
+	realm := "it-get-" + testID
 	cluster := "cli-get-" + testID
 
-	netName := docker.NetworkName(testRealm + "-" + cluster + "-net")
-	ctrName := docker.ContainerName(testRealm + "-" + cluster + "-controller")
-	volConfig := docker.VolumeName(testRealm + "-" + cluster + "-config")
-	volMunge := docker.VolumeName(testRealm + "-" + cluster + "-munge")
-	volData := docker.VolumeName(testRealm + "-" + cluster + "-data")
+	netName := docker.NetworkName(realm + "-" + cluster + "-net")
+	ctrName := docker.ContainerName(realm + "-" + cluster + "-controller")
+	volConfig := docker.VolumeName(realm + "-" + cluster + "-config")
+	volMunge := docker.VolumeName(realm + "-" + cluster + "-munge")
+	volData := docker.VolumeName(realm + "-" + cluster + "-data")
 
 	t.Cleanup(func() {
 		bg := context.Background()
@@ -246,7 +249,7 @@ func TestGetLifecycle(t *testing.T) {
 	_, err = c.RunContainer(ctx,
 		"--name", string(ctrName),
 		"--network", string(netName),
-		"--label", "sind.realm="+testRealm,
+		"--label", "sind.realm="+realm,
 		"--label", "sind.cluster="+cluster,
 		"--label", "sind.role=controller",
 		"--label", "sind.slurm.version=25.11.0",
@@ -257,31 +260,31 @@ func TestGetLifecycle(t *testing.T) {
 	require.NoError(t, c.WriteFile(ctx, ctrName, "/etc/munge/munge.key", "test-munge-key"))
 
 	// get clusters
-	stdout, _, err := executeWithDocker("get", "clusters")
+	stdout, _, err := executeWithRealm(realm, "get", "clusters")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, cluster)
 	assert.Contains(t, stdout, "25.11.0")
 	assert.Contains(t, stdout, "running")
 
 	// get nodes
-	stdout, _, err = executeWithDocker("get", "nodes", cluster)
+	stdout, _, err = executeWithRealm(realm, "get", "nodes", cluster)
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "controller."+cluster)
 
 	// get networks
-	stdout, _, err = executeWithDocker("get", "networks")
+	stdout, _, err = executeWithRealm(realm, "get", "networks")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, string(netName))
 
 	// get volumes
-	stdout, _, err = executeWithDocker("get", "volumes")
+	stdout, _, err = executeWithRealm(realm, "get", "volumes")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, string(volConfig))
 	assert.Contains(t, stdout, string(volMunge))
 	assert.Contains(t, stdout, string(volData))
 
 	// get munge-key
-	stdout, _, err = executeWithDocker("get", "munge-key", cluster)
+	stdout, _, err = executeWithRealm(realm, "get", "munge-key", cluster)
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "dGVzdC1tdW5nZS1rZXk=") // base64("test-munge-key")
 }

--- a/cmd/sind/mode_integration_test.go
+++ b/cmd/sind/mode_integration_test.go
@@ -36,6 +36,21 @@ func executeWithDocker(args ...string) (string, string, error) {
 	return executeWithDockerCtx(context.Background(), args...)
 }
 
+// executeWithRealm runs a CLI command with --realm prepended.
+func executeWithRealm(realm string, args ...string) (string, string, error) {
+	return executeWithDocker(append([]string{"--realm", realm}, args...)...)
+}
+
+// executeWithRealmCtx runs a CLI command with --realm prepended and a context.
+func executeWithRealmCtx(ctx context.Context, realm string, args ...string) (string, string, error) {
+	return executeWithDockerCtx(ctx, append([]string{"--realm", realm}, args...)...)
+}
+
+// executeWithRealmStdin runs a CLI command with --realm prepended and piped stdin.
+func executeWithRealmStdin(ctx context.Context, realm string, stdin string, args ...string) (string, string, error) {
+	return executeWithStdin(ctx, stdin, append([]string{"--realm", realm}, args...)...)
+}
+
 // executeWithDockerCtx runs a CLI command backed by a real Docker client
 // with the given context (e.g. for deadline control on long-running commands).
 func executeWithDockerCtx(ctx context.Context, args ...string) (string, string, error) {

--- a/cmd/sind/mode_unit_test.go
+++ b/cmd/sind/mode_unit_test.go
@@ -12,15 +12,6 @@ import (
 )
 
 var testID = "unit"
-var testRealm = "sind"
-
-func executeWithDocker(_ ...string) (string, string, error) {
-	panic("executeWithDocker called in unit mode")
-}
-
-func executeWithDockerCtx(_ context.Context, _ ...string) (string, string, error) {
-	panic("executeWithDockerCtx called in unit mode")
-}
 
 func realClient(t *testing.T) *docker.Client {
 	t.Helper()
@@ -37,4 +28,12 @@ func testImage(t *testing.T) string {
 	t.Helper()
 	t.Skip("integration test")
 	return ""
+}
+
+func executeWithRealm(_ string, _ ...string) (string, string, error) {
+	panic("executeWithRealm called in unit mode")
+}
+
+func executeWithRealmCtx(_ context.Context, _ string, _ ...string) (string, string, error) {
+	panic("executeWithRealmCtx called in unit mode")
 }

--- a/cmd/sind/power_test.go
+++ b/cmd/sind/power_test.go
@@ -38,12 +38,13 @@ func TestPower_RequiresArgs(t *testing.T) {
 // --- Integration ---
 
 func TestPowerLifecycle(t *testing.T) {
+	t.Parallel()
 	c := realClient(t)
 	ctx := t.Context()
-	t.Setenv("SIND_REALM", testRealm)
+	realm := "it-pwr-" + testID
 	cluster := "cli-pwr-" + testID
 
-	ctrName := docker.ContainerName(testRealm + "-" + cluster + "-worker-0")
+	ctrName := docker.ContainerName(realm + "-" + cluster + "-worker-0")
 
 	t.Cleanup(func() {
 		bg := context.Background()
@@ -53,7 +54,7 @@ func TestPowerLifecycle(t *testing.T) {
 
 	_, err := c.RunContainer(ctx,
 		"--name", string(ctrName),
-		"--label", "sind.realm="+testRealm,
+		"--label", "sind.realm="+realm,
 		"--label", "sind.cluster="+cluster,
 		"--label", "sind.role=worker",
 		"busybox:latest", "sleep", "120",
@@ -63,49 +64,49 @@ func TestPowerLifecycle(t *testing.T) {
 	node := "worker-0." + cluster
 
 	// shutdown (stop)
-	_, _, err = executeWithDocker("power", "shutdown", node)
+	_, _, err = executeWithRealm(realm, "power", "shutdown", node)
 	require.NoError(t, err)
 	info, err := c.InspectContainer(ctx, ctrName)
 	require.NoError(t, err)
 	assert.Equal(t, "exited", info.Status)
 
 	// on (start)
-	_, _, err = executeWithDocker("power", "on", node)
+	_, _, err = executeWithRealm(realm, "power", "on", node)
 	require.NoError(t, err)
 	info, err = c.InspectContainer(ctx, ctrName)
 	require.NoError(t, err)
 	assert.Equal(t, "running", info.Status)
 
 	// freeze (pause)
-	_, _, err = executeWithDocker("power", "freeze", node)
+	_, _, err = executeWithRealm(realm, "power", "freeze", node)
 	require.NoError(t, err)
 	info, err = c.InspectContainer(ctx, ctrName)
 	require.NoError(t, err)
 	assert.Equal(t, "paused", info.Status)
 
 	// unfreeze (unpause)
-	_, _, err = executeWithDocker("power", "unfreeze", node)
+	_, _, err = executeWithRealm(realm, "power", "unfreeze", node)
 	require.NoError(t, err)
 	info, err = c.InspectContainer(ctx, ctrName)
 	require.NoError(t, err)
 	assert.Equal(t, "running", info.Status)
 
 	// reboot (stop + start)
-	_, _, err = executeWithDocker("power", "reboot", node)
+	_, _, err = executeWithRealm(realm, "power", "reboot", node)
 	require.NoError(t, err)
 	info, err = c.InspectContainer(ctx, ctrName)
 	require.NoError(t, err)
 	assert.Equal(t, "running", info.Status)
 
 	// cycle (kill + start)
-	_, _, err = executeWithDocker("power", "cycle", node)
+	_, _, err = executeWithRealm(realm, "power", "cycle", node)
 	require.NoError(t, err)
 	info, err = c.InspectContainer(ctx, ctrName)
 	require.NoError(t, err)
 	assert.Equal(t, "running", info.Status)
 
 	// cut (kill)
-	_, _, err = executeWithDocker("power", "cut", node)
+	_, _, err = executeWithRealm(realm, "power", "cut", node)
 	require.NoError(t, err)
 	info, err = c.InspectContainer(ctx, ctrName)
 	require.NoError(t, err)

--- a/cmd/sind/quickstart_test.go
+++ b/cmd/sind/quickstart_test.go
@@ -21,13 +21,13 @@ import (
 // Each section comment references the corresponding guide heading.
 // Keep in sync with docs/content/getting-started/quickstart.md.
 func TestQuickstart(t *testing.T) {
-	t.Chdir(t.TempDir())
+	t.Parallel()
+	dataDir := t.TempDir()
 	c := realClient(t)
 	skipIfNoNsdelegate(t)
 	image := testImage(t)
 
 	realm := "it-qs-" + testID
-	t.Setenv("SIND_REALM", realm)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	defer cancel()
@@ -56,25 +56,25 @@ func TestQuickstart(t *testing.T) {
 	minimalCfg := filepath.Join(cfgDir, "minimal.yaml")
 	require.NoError(t, os.WriteFile(minimalCfg, []byte("kind: Cluster\ndefaults:\n  image: "+image+"\n"), 0o644))
 
-	_, stderr, err := executeWithDockerCtx(ctx, "create", "cluster", "--config", minimalCfg)
+	_, stderr, err := executeWithRealmCtx(ctx, realm, "create", "cluster", "--config", minimalCfg, "--data", dataDir)
 	require.NoError(t, err, "create cluster: stderr=%q", stderr)
 
 	// ## Check cluster status
 	// sind get clusters
 	var stdout string
-	stdout, _, err = executeWithDockerCtx(ctx, "get", "clusters")
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "get", "clusters")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "default")
 	assert.Contains(t, stdout, "running")
 
 	// sind get nodes
-	stdout, _, err = executeWithDockerCtx(ctx, "get", "nodes")
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "get", "nodes")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "controller.default")
 	assert.Contains(t, stdout, "worker-0.default")
 
 	// sind status
-	stdout, _, err = executeWithDockerCtx(ctx, "status")
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "status")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "CLUSTER")
 	assert.Contains(t, stdout, "default")
@@ -85,55 +85,55 @@ func TestQuickstart(t *testing.T) {
 
 	// ## Run Slurm commands
 	// sind exec -- sinfo
-	stdout, stderr, err = executeWithDockerCtx(ctx, "exec", "--", "sinfo")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "--", "sinfo")
 	require.NoError(t, err, "exec sinfo: stdout=%q stderr=%q", stdout, stderr)
 	assert.Contains(t, stdout, "PARTITION")
 
 	// sind exec -- srun hostname
-	stdout, stderr, err = executeWithDockerCtx(ctx, "exec", "--", "srun", "hostname")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "--", "srun", "hostname")
 	require.NoError(t, err, "exec srun hostname: stdout=%q stderr=%q", stdout, stderr)
 	assert.Contains(t, stdout, "worker-0")
 
 	// ### Submit a batch job
 	// Create batch script via exec (lands in /data = test temp dir)
-	_, stderr, err = executeWithDockerCtx(ctx, "exec", "--", "sh", "-c", `printf '#!/bin/sh\n#SBATCH --job-name=hello\nhostname\nsleep 30\n' > job.sh`)
+	_, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "--", "sh", "-c", `printf '#!/bin/sh\n#SBATCH --job-name=hello\nhostname\nsleep 2\n' > job.sh`)
 	require.NoError(t, err, "create job script: stderr=%q", stderr)
 
 	// sind exec -- sbatch job.sh
-	stdout, stderr, err = executeWithDockerCtx(ctx, "exec", "--", "sbatch", "job.sh")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "--", "sbatch", "job.sh")
 	require.NoError(t, err, "sbatch: stdout=%q stderr=%q", stdout, stderr)
 	assert.Contains(t, stdout, "Submitted batch job")
 
 	// sind exec -- squeue (job should still be running thanks to sleep)
-	stdout, _, err = executeWithDockerCtx(ctx, "exec", "--", "squeue")
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "exec", "--", "squeue")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "hello")
 
 	// Wait for job to finish, then verify output file
-	_, stderr, err = executeWithDockerCtx(ctx, "exec", "--", "sh", "-c", "while squeue -h -n hello | grep -q hello; do sleep 2; done")
+	_, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "--", "sh", "-c", "while squeue -h -n hello | grep -q hello; do sleep 1; done")
 	require.NoError(t, err, "wait for job: stderr=%q", stderr)
 
-	stdout, _, err = executeWithDockerCtx(ctx, "exec", "--", "sh", "-c", "cat slurm-*.out")
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "exec", "--", "sh", "-c", "cat slurm-*.out")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "worker-0")
 
 	// ## SSH into a node
 	// sind ssh controller
-	stdout, stderr, err = executeWithDockerCtx(ctx, "ssh", "controller", "--", "hostname")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "ssh", "controller", "--", "hostname")
 	require.NoError(t, err, "ssh controller: stdout=%q stderr=%q", stdout, stderr)
 	assert.Contains(t, stdout, "controller")
 
 	// sind ssh worker-0
-	stdout, stderr, err = executeWithDockerCtx(ctx, "ssh", "worker-0", "--", "hostname")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "ssh", "worker-0", "--", "hostname")
 	require.NoError(t, err, "ssh worker-0: stdout=%q stderr=%q", stdout, stderr)
 	assert.Contains(t, stdout, "worker-0")
 
 	// ## Scale up
 	// sind create worker --count 3
-	_, stderr, err = executeWithDockerCtx(ctx, "create", "worker", "--count", "3")
+	_, stderr, err = executeWithRealmCtx(ctx, realm, "create", "worker", "--count", "3")
 	require.NoError(t, err, "create worker: stderr=%q", stderr)
 
-	stdout, _, err = executeWithDockerCtx(ctx, "get", "nodes")
+	stdout, _, err = executeWithRealmCtx(ctx, realm, "get", "nodes")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "worker-1.default")
 	assert.Contains(t, stdout, "worker-2.default")
@@ -141,23 +141,23 @@ func TestQuickstart(t *testing.T) {
 
 	// ## Tear down
 	// sind delete cluster default
-	_, _, err = executeWithDockerCtx(ctx, "delete", "cluster", "default")
+	_, _, err = executeWithRealmCtx(ctx, realm, "delete", "cluster", "default")
 	require.NoError(t, err)
 
 	// ## Going further — named clusters with custom configuration
 	devYAML := "kind: Cluster\nname: dev\ndefaults:\n  image: " + image + "\n  cpus: 2\n  memory: 1g\nnodes:\n  - controller\n  - submitter\n  - worker: 3\n"
 
-	_, stderr, err = executeWithStdin(ctx, devYAML, "create", "cluster")
+	_, stderr, err = executeWithRealmStdin(ctx, realm, devYAML, "create", "cluster", "--data", dataDir)
 	require.NoError(t, err, "create dev cluster: stderr=%q", stderr)
 
 	// Verify submitter is present and exec routes to it.
-	stdout, stderr, err = executeWithDockerCtx(ctx, "exec", "dev", "--", "hostname")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "dev", "--", "hostname")
 	require.NoError(t, err, "exec dev hostname: stdout=%q stderr=%q", stdout, stderr)
 	assert.Contains(t, stdout, "submitter")
 
 	// Cleanup: delete remaining cluster
 	// sind delete cluster --all
-	_, _, err = executeWithDockerCtx(ctx, "delete", "cluster", "--all")
+	_, _, err = executeWithRealmCtx(ctx, realm, "delete", "cluster", "--all")
 	require.NoError(t, err)
 
 	// Verify everything is gone.

--- a/cmd/sind/ssh_test.go
+++ b/cmd/sind/ssh_test.go
@@ -122,29 +122,29 @@ func TestParseExecArgs_ExtraArgsBefore(t *testing.T) {
 // TestSSHAccess exercises all SSH access methods against a real cluster:
 // sind ssh, sind enter, sind exec, and user SSH client via exported ssh_config.
 func TestSSHAccess(t *testing.T) {
-	t.Chdir(t.TempDir())
+	t.Parallel()
 	c := realClient(t)
 	skipIfNoNsdelegate(t)
 	image := testImage(t)
+	dataDir := t.TempDir()
 
-	t.Setenv("SIND_REALM", testRealm)
-
+	realm := "it-ssh-" + testID
 	cluster := "e2e-ssh-" + testID
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
 	defer cancel()
 
-	meshMgr := mesh.NewManager(c, testRealm)
+	meshMgr := mesh.NewManager(c, realm)
 	t.Cleanup(func() {
 		bg := context.Background()
 		for _, name := range []string{"controller", "submitter", "worker-0"} {
-			cn := docker.ContainerName(testRealm + "-" + cluster + "-" + name)
+			cn := docker.ContainerName(realm + "-" + cluster + "-" + name)
 			_ = c.KillContainer(bg, cn)
 			_ = c.RemoveContainer(bg, cn)
 		}
 		for _, vt := range []string{"config", "munge", "data"} {
-			_ = c.RemoveVolume(bg, docker.VolumeName(testRealm+"-"+cluster+"-"+vt))
+			_ = c.RemoveVolume(bg, docker.VolumeName(realm+"-"+cluster+"-"+vt))
 		}
-		_ = c.RemoveNetwork(bg, docker.NetworkName(testRealm+"-"+cluster+"-net"))
+		_ = c.RemoveNetwork(bg, docker.NetworkName(realm+"-"+cluster+"-net"))
 		_ = meshMgr.CleanupMesh(bg)
 	})
 
@@ -154,20 +154,20 @@ func TestSSHAccess(t *testing.T) {
 	cfg := "kind: Cluster\nname: " + cluster + "\ndefaults:\n  image: " + image + "\nnodes:\n  - controller\n  - submitter\n  - worker: 1\n"
 	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o644))
 
-	stdout, stderr, err := executeWithDockerCtx(ctx, "create", "cluster", "--config", cfgPath)
+	stdout, stderr, err := executeWithRealmCtx(ctx, realm, "create", "cluster", "--config", cfgPath, "--data", dataDir)
 	require.NoError(t, err, "create cluster: stdout=%q stderr=%q", stdout, stderr)
 
 	// --- sind ssh: run command on specific node ---
-	stdout, stderr, err = executeWithDockerCtx(ctx, "ssh", "controller."+cluster, "--", "hostname")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "ssh", "controller."+cluster, "--", "hostname")
 	require.NoError(t, err, "ssh controller: stdout=%q stderr=%q", stdout, stderr)
 	assert.Contains(t, stdout, "controller")
 
-	stdout, stderr, err = executeWithDockerCtx(ctx, "ssh", "worker-0."+cluster, "--", "hostname")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "ssh", "worker-0."+cluster, "--", "hostname")
 	require.NoError(t, err, "ssh worker-0: stdout=%q stderr=%q", stdout, stderr)
 	assert.Contains(t, stdout, "worker-0")
 
 	// --- sind enter: routes to submitter when present ---
-	stdout, stderr, err = executeWithDockerCtx(ctx, "enter", cluster)
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "enter", cluster)
 	// enter opens an interactive shell — will exit immediately since stdin is not a TTY.
 	// But the connection itself should succeed (exit code 0 or similar).
 	// We can't assert much about stdout here since it's an interactive session.
@@ -176,12 +176,12 @@ func TestSSHAccess(t *testing.T) {
 	_ = err
 
 	// --- sind exec: routes to submitter when present ---
-	stdout, stderr, err = executeWithDockerCtx(ctx, "exec", cluster, "--", "hostname")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "exec", cluster, "--", "hostname")
 	require.NoError(t, err, "exec: stdout=%q stderr=%q", stdout, stderr)
 	assert.Contains(t, stdout, "submitter", "exec should route to submitter when present")
 
 	// --- user SSH client via exported ssh_config ---
-	sshConfigDir, err := sindStateDir(testRealm)
+	sshConfigDir, err := sindStateDir(realm)
 	require.NoError(t, err)
 	sshConfigPath := filepath.Join(sshConfigDir, "ssh_config")
 
@@ -190,7 +190,7 @@ func TestSSHAccess(t *testing.T) {
 		sshCmd := exec.CommandContext(ctx, "ssh",
 			"-F", sshConfigPath,
 			"-o", "BatchMode=yes",
-			"controller."+cluster+"."+testRealm+".sind",
+			"controller."+cluster+"."+realm+".sind",
 			"hostname",
 		)
 		out, sshErr := sshCmd.CombinedOutput()
@@ -201,7 +201,7 @@ func TestSSHAccess(t *testing.T) {
 		sshCmd = exec.CommandContext(ctx, "ssh",
 			"-F", sshConfigPath,
 			"-o", "BatchMode=yes",
-			"worker-0."+cluster+"."+testRealm+".sind",
+			"worker-0."+cluster+"."+realm+".sind",
 			"hostname",
 		)
 		out, sshErr = sshCmd.CombinedOutput()
@@ -210,6 +210,6 @@ func TestSSHAccess(t *testing.T) {
 	}
 
 	// --- delete cluster ---
-	_, _, err = executeWithDockerCtx(ctx, "delete", "cluster", cluster)
+	_, _, err = executeWithRealmCtx(ctx, realm, "delete", "cluster", cluster)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Parallelize all cmd/sind integration tests with `t.Parallel()`, reducing
wall time from ~119s to ~41s (3x faster).

- replace `t.Setenv`/`t.Chdir` (incompatible with `t.Parallel()`) with
  explicit `--realm` and `--data` flags passed to CLI commands
- give each test its own unique realm to prevent cross-test interference
- add `executeWithRealm`/`executeWithRealmCtx`/`executeWithRealmStdin` helpers
- reduce batch job sleep from 30s to 2s in TestQuickstart
- remove unused stubs from mode_unit_test.go