### PR TITLE
ci: parallelize unit and integration test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v9
 
-  test:
-    name: Test
+  unit-test:
+    name: Unit Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -40,6 +40,27 @@ jobs:
         env:
           GOTEST: gotestsum --junitfile unit-tests.xml --
 
+      - name: Test report
+        uses: dorny/test-reporter@v3
+        if: always()
+        with:
+          name: Unit Test Results
+          path: unit-tests.xml
+          reporter: java-junit
+
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Integration tests
         run: make test-integration
         env:
@@ -49,8 +70,8 @@ jobs:
         uses: dorny/test-reporter@v3
         if: always()
         with:
-          name: Test Results
-          path: "*-tests.xml"
+          name: Integration Test Results
+          path: integration-tests.xml
           reporter: java-junit
 
   build:


### PR DESCRIPTION
Split the single `test` job into `unit-test` and `integration-test` jobs that run concurrently, each with its own setup and test report.