### PR TITLE
docs: fix stale glob references in map-form config descriptions

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -568,7 +568,7 @@ nodes:
 The `slurm` key contains named sections that map to Slurm config files. Each section supports two forms:
 
 - **String**: content appended directly to the config file
-- **Map**: each key creates a fragment in a `.conf.d/` directory, included via `include <name>.conf.d/*`
+- **Map**: each key creates a fragment in a `.conf.d/` directory, included via explicit `include` directives per fragment file
 
 | Section | Config file | sind generates defaults |
 |---------|-------------|:----------------------:|
@@ -605,7 +605,7 @@ This produces:
 
 ```
 /etc/slurm/
-├── slurm.conf              # sind defaults + include slurm.conf.d/*
+├── slurm.conf              # sind defaults + explicit includes per fragment
 ├── slurm.conf.d/
 │   ├── resources.conf
 │   └── scheduling.conf

--- a/docs/content/architecture/slurm-config.md
+++ b/docs/content/architecture/slurm-config.md
@@ -68,7 +68,7 @@ slurm:
     ConstrainCores=yes
 ```
 
-**Map form** — named fragments in a `.conf.d/` directory, included via glob:
+**Map form** — named fragments in a `.conf.d/` directory, included explicitly:
 
 ```yaml
 slurm:
@@ -79,7 +79,7 @@ slurm:
       SelectType=select/cons_tres
 ```
 
-This creates `slurm.conf.d/scheduling.conf` and `slurm.conf.d/resources.conf`, with `include /etc/slurm/slurm.conf.d/*` appended to `slurm.conf`.
+This creates `slurm.conf.d/scheduling.conf` and `slurm.conf.d/resources.conf`, with explicit include directives appended to `slurm.conf` for each fragment file. Glob includes are not used because Slurm's main config parser does not support them (the SPANK `plugstack.conf` parser does).
 
 Standalone sections (`gres`, `topology`) are only created when configured and require enabling in `slurm.conf` via the `main` section (e.g., `GresTypes=gpu`).
 


### PR DESCRIPTION
Follow-up to #31 — DESIGN.md and the slurm-config architecture page
still referenced glob includes (`include slurm.conf.d/*`) for the map
form. Updated to reflect that explicit per-fragment include directives
are used instead, since Slurm's main config parser does not support
globs.