### PR TITLE
fix(docs): preserve main site when deploying next docs

### DIFF
--- a/.github/workflows/docs-next.yml
+++ b/.github/workflows/docs-next.yml
@@ -43,3 +43,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/public
           destination_dir: next
+          keep_files: true


### PR DESCRIPTION
Add `keep_files: true` to the deploy-next workflow's `peaceiris/actions-gh-pages` step.

Without this flag, deploying next docs wipes the entire `gh-pages` branch and deletes the main site content — causing a 404 on the root site.

The main `docs.yml` workflow already sets `keep_files: true`; this aligns the next workflow to match.