### PR TITLE
Add OpenMPI, PMIx, UCX, and PRRTE support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,25 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build sind-node image
+        uses: docker/bake-action@v7
+        with:
+          load: true
+          allow: network.host
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
+            *.tags=local/sind-node:ci
+
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
       - name: Integration tests
         run: make test-integration
         env:
+          SIND_TEST_IMAGE: local/sind-node:ci
           GOTEST: gotestsum --junitfile integration-tests.xml --
 
       - name: Test report

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - "Dockerfile"
       - "docker-bake.hcl"
-  pull_request:
-    paths:
-      - "Dockerfile"
-      - "docker-bake.hcl"
   workflow_dispatch:
 
 permissions:
@@ -36,6 +32,10 @@ jobs:
         uses: docker/bake-action@v7
         with:
           push: ${{ github.event_name != 'pull_request' }}
+          allow: network.host
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
 
       - name: Tag latest if this is the highest version
         if: github.event_name != 'pull_request'

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,9 +11,10 @@ A CLI tool for running local Slurm clusters using Docker containers, inspired by
 - Linux host with cgroupv2 and `nsdelegate` mount option (`mount -o remount,nsdelegate /sys/fs/cgroup`)
 - Docker Engine 28.0+ (required for `--security-opt writable-cgroups=true`)
 
-## Supported Slurm Versions
+## Supported Versions
 
 - Slurm 25.11
+- OpenMPI 5.0 (with PMIx 6.x, PRRTE 4.x, UCX 1.20)
 
 ## Overview
 
@@ -944,11 +945,12 @@ This is the default image when `defaults.image` is not specified in the cluster 
 
 The generic image:
 - Based on Rocky Linux 10
-- Builds Slurm from source for each release
-- Contains all daemons (slurmctld, slurmd)
+- Builds Slurm, OpenMPI, PMIx, PRRTE, and UCX from source
+- Contains all Slurm daemons (slurmctld, slurmd) and a full MPI stack
+- Slurm is built with `--with-pmix` for native PMIx job launch support
 - sind enables the appropriate services based on node role
 
-The `Dockerfile` and `docker-bake.hcl` are in the repository root.
+The `Dockerfile` uses a multi-stage build with a shared `builder-base` stage. UCX and PMIx build in parallel, PRRTE and Slurm depend on PMIx, and OpenMPI depends on all three. Component versions are pinned as `ARG` defaults in the Dockerfile and mirrored in `docker-bake.hcl`.
 
 ### Custom Images
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,28 +30,107 @@
 #   docker buildx bake
 
 # ==============================================================================
-# Stage 1: Builder — compile Slurm from source
+# Stage: builder-base — Rocky 10 with common build toolchain
 # ==============================================================================
-FROM quay.io/rockylinux/rockylinux:10 AS builder
+FROM quay.io/rockylinux/rockylinux:10 AS builder-base
 
-ARG SLURM_VERSION=25.11.4
-
-# EPEL + CRB are required for munge-devel and other build headers
 RUN dnf -y install epel-release dnf-plugins-core && \
     dnf config-manager --set-enabled crb
 
-# Build toolchain and Slurm's compile-time dependencies
 RUN dnf -y install \
         gcc gcc-c++ make \
+        libevent-devel \
+        hwloc-devel \
+        python3 perl flex pkgconf \
+        tar bzip2 diffutils \
+    && dnf clean all
+
+# ==============================================================================
+# Stage: ucx-builder — compile UCX from source
+# ==============================================================================
+FROM builder-base AS ucx-builder
+
+ARG UCX_VERSION=1.20.0
+
+ADD --checksum=sha256:7c8a6093cada179aa1d851b83625e3b25ed5658966e309de5118c27a038c7ef9 \
+    https://github.com/openucx/ucx/releases/download/v${UCX_VERSION}/ucx-${UCX_VERSION}.tar.gz \
+    /tmp/ucx.tar.gz
+
+WORKDIR /tmp
+RUN tar xf ucx.tar.gz && \
+    cd ucx-${UCX_VERSION} && \
+    ./configure \
+        --prefix=/usr \
+        --libdir=/usr/lib64 \
+        --disable-static \
+        --without-cuda \
+        --without-rocm \
+        --without-java && \
+    make -j$(nproc) && \
+    DESTDIR=/install make install
+
+# ==============================================================================
+# Stage: pmix-builder — compile PMIx from source
+# ==============================================================================
+FROM builder-base AS pmix-builder
+
+ARG PMIX_VERSION=6.1.0
+
+ADD --checksum=sha256:bb9021c8e100a376f5070ecca727f83a29b5f652dfe381793b88daa79a3b98a2 \
+    https://github.com/openpmix/openpmix/releases/download/v${PMIX_VERSION}/pmix-${PMIX_VERSION}.tar.bz2 \
+    /tmp/pmix.tar.bz2
+
+WORKDIR /tmp
+RUN tar xf pmix.tar.bz2 && \
+    cd pmix-${PMIX_VERSION} && \
+    ./configure \
+        --prefix=/usr \
+        --libdir=/usr/lib64 \
+        --disable-static && \
+    make -j$(nproc) && \
+    DESTDIR=/install make install
+
+# ==============================================================================
+# Stage: prrte-builder — compile PRRTE from source (with PMIx 6.x)
+# ==============================================================================
+FROM builder-base AS prrte-builder
+
+ARG PRRTE_VERSION=4.1.0
+
+COPY --from=pmix-builder /install/usr /usr
+
+ADD --checksum=sha256:285ad62b670075708b9fcfe14c54baa599733bc274d10502a82e8eebba0b7c70 \
+    https://github.com/openpmix/prrte/releases/download/v${PRRTE_VERSION}/prrte-${PRRTE_VERSION}.tar.bz2 \
+    /tmp/prrte.tar.bz2
+
+WORKDIR /tmp
+RUN tar xf prrte.tar.bz2 && \
+    cd prrte-${PRRTE_VERSION} && \
+    ./configure \
+        --prefix=/usr \
+        --libdir=/usr/lib64 \
+        --disable-static && \
+    make -j$(nproc) && \
+    DESTDIR=/install make install
+
+# ==============================================================================
+# Stage: slurm-builder — compile Slurm from source (with PMIx support)
+# ==============================================================================
+FROM builder-base AS slurm-builder
+
+ARG SLURM_VERSION=25.11.4
+
+# PMIx headers and libraries are needed for Slurm's PMIx launch plugin.
+COPY --from=pmix-builder /install/usr /usr
+
+RUN dnf -y install \
         munge-devel \
         pam-devel \
         readline-devel \
         perl-ExtUtils-MakeMaker \
-        python3 \
         mariadb-devel \
         dbus-devel \
         libbpf-devel \
-        tar bzip2 \
     && dnf clean all
 
 # Fetch the Slurm source tarball with integrity verification.
@@ -70,24 +149,63 @@ RUN tar xf slurm.tar.bz2 && \
         --localstatedir=/var \
         --runstatedir=/run \
         --with-munge \
+        --with-pmix \
         --with-pam_dir=/usr/lib64/security \
         --with-systemdsystemunitdir=/usr/lib/systemd/system && \
     make -j$(nproc) && \
-    DESTDIR=/slurm-install make install && \
-    mkdir -p /slurm-install/etc
+    DESTDIR=/install make install && \
+    mkdir -p /install/etc
 
 # ==============================================================================
-# Stage 2: Runtime — lean image with only the packages needed at run time
+# Stage: ompi-builder — compile OpenMPI from source (with PRRTE + PMIx + UCX)
+# ==============================================================================
+FROM builder-base AS ompi-builder
+
+ARG OMPI_VERSION=5.0.10
+
+COPY --from=ucx-builder /install/usr /usr
+COPY --from=pmix-builder /install/usr /usr
+COPY --from=prrte-builder /install/usr /usr
+
+ADD --checksum=sha256:0acecc4fc218e5debdbcb8a41d182c6b0f1d29393015ed763b2a91d5d7374cc6 \
+    https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-${OMPI_VERSION}.tar.bz2 \
+    /tmp/openmpi.tar.bz2
+
+WORKDIR /tmp
+RUN tar xf openmpi.tar.bz2 && \
+    cd openmpi-${OMPI_VERSION} && \
+    ./configure \
+        --prefix=/usr \
+        --libdir=/usr/lib64 \
+        --disable-static \
+        --with-pmix \
+        --with-prrte=external \
+        --with-ucx \
+        --with-hwloc=external \
+        --with-libevent=external \
+        --without-cuda \
+        --without-rocm && \
+    make -j$(nproc) && \
+    DESTDIR=/install make install
+
+# ==============================================================================
+# Stage: runtime — lean image with only the packages needed at run time
 # ==============================================================================
 FROM quay.io/rockylinux/rockylinux:10
 
 ARG SLURM_VERSION=25.11.4
+ARG UCX_VERSION=1.20.0
+ARG PMIX_VERSION=6.1.0
+ARG PRRTE_VERSION=4.1.0
+ARG OMPI_VERSION=5.0.10
 
 RUN dnf -y install epel-release dnf-plugins-core && \
     dnf config-manager --set-enabled crb
 
-# Runtime dependencies — no compilers or -devel packages.
+# Runtime dependencies.
+# gcc is needed by mpicc (OpenMPI's wrapper compiler).
 # mariadb-server is included for the db role (slurmdbd accounting storage).
+# libevent and hwloc-libs are required by PMIx, PRRTE, and OpenMPI at runtime.
 RUN dnf -y install \
         systemd \
         munge \
@@ -100,12 +218,18 @@ RUN dnf -y install \
         openssh-server \
         openssh-clients \
         dbus-libs \
+        libevent \
+        hwloc-libs \
+        gcc \
     && dnf clean all
 
-# Bring in only the compiled Slurm binaries, libraries, and config from the
-# builder stage — keeps the final image small.
-COPY --from=builder /slurm-install/usr /usr
-COPY --from=builder /slurm-install/etc /etc
+# Bring in compiled artifacts from each builder stage.
+COPY --from=slurm-builder /install/usr /usr
+COPY --from=slurm-builder /install/etc /etc
+COPY --from=ucx-builder /install/usr /usr
+COPY --from=pmix-builder /install/usr /usr
+COPY --from=prrte-builder /install/usr /usr
+COPY --from=ompi-builder /install/usr /usr
 
 # Slurm daemons run as the unprivileged slurm user
 RUN useradd -r -s /sbin/nologin slurm
@@ -149,7 +273,11 @@ RUN systemctl mask \
 LABEL org.opencontainers.image.title="sind-node" \
       org.opencontainers.image.description="Generic Slurm node for sind" \
       org.opencontainers.image.version="${SLURM_VERSION}" \
-      sind.slurm.version="${SLURM_VERSION}"
+      sind.slurm.version="${SLURM_VERSION}" \
+      sind.ucx.version="${UCX_VERSION}" \
+      sind.pmix.version="${PMIX_VERSION}" \
+      sind.prrte.version="${PRRTE_VERSION}" \
+      sind.ompi.version="${OMPI_VERSION}"
 
 VOLUME ["/etc/slurm", "/etc/munge", "/data"]
 WORKDIR /data

--- a/cmd/sind/mpi_test.go
+++ b/cmd/sind/mpi_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GSI-HPC/sind/pkg/docker"
+	"github.com/GSI-HPC/sind/pkg/mesh"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMPI creates a 3-worker cluster and runs a basic MPI program via srun.
+func TestMPI(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+	c := realClient(t)
+	checkPrerequisites(t, c)
+	image := testImage(t)
+
+	realm := "it-mpi-" + testID
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	meshMgr := mesh.NewManager(c, realm)
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, name := range []string{"controller", "worker-0", "worker-1", "worker-2"} {
+			cn := docker.ContainerName(realm + "-default-" + name)
+			_ = c.KillContainer(bg, cn)
+			_ = c.RemoveContainer(bg, cn)
+		}
+		for _, vt := range []string{"config", "munge", "data"} {
+			_ = c.RemoveVolume(bg, docker.VolumeName(realm+"-default-"+vt))
+		}
+		_ = c.RemoveNetwork(bg, docker.NetworkName(realm+"-default-net"))
+		_ = meshMgr.CleanupMesh(bg)
+	})
+
+	// Create a cluster with 3 workers for multi-node MPI.
+	cfg := "kind: Cluster\ndefaults:\n  image: " + image + "\nnodes:\n  - controller\n  - worker: 3\n"
+	_, stderr, err := executeWithRealmStdin(ctx, realm, cfg, "create", "cluster", "--data", dataDir)
+	require.NoError(t, err, "create cluster: stderr=%q", stderr)
+
+	// Verify the MPI stack is functional via ompi_info.
+	stdout, stderr, err := executeWithRealmCtx(ctx, realm, "exec", "--", "ompi_info", "--all")
+	require.NoError(t, err, "ompi_info: stderr=%q", stderr)
+	assert.Contains(t, stdout, "Open MPI")
+	assert.Contains(t, stdout, "MCA pmix")
+	assert.Contains(t, stdout, "MCA pml: ucx")
+	t.Logf("ompi_info output:\n%s", stdout)
+
+	// Compile a minimal MPI program with a global barrier inside the cluster.
+	mpiSource := `
+#include <mpi.h>
+#include <stdio.h>
+#include <unistd.h>
+int main(int argc, char **argv) {
+    MPI_Init(&argc, &argv);
+    int rank, size;
+    char hostname[256];
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    gethostname(hostname, sizeof(hostname));
+    MPI_Barrier(MPI_COMM_WORLD);
+    printf("rank %d of %d on %s\\n", rank, size, hostname);
+    MPI_Finalize();
+    return 0;
+}
+`
+	_, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "--", "sh", "-c", "cat > hello_mpi.c << 'CSRC'\n"+mpiSource+"CSRC")
+	require.NoError(t, err, "write source: stderr=%q", stderr)
+
+	_, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "--", "mpicc", "-o", "hello_mpi", "hello_mpi.c")
+	require.NoError(t, err, "mpicc: stderr=%q", stderr)
+
+	// Run across all 3 workers with one task per node.
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "--", "srun", "-N3", "--ntasks-per-node=1", "--mpi=pmix", "./hello_mpi")
+	require.NoError(t, err, "srun mpi: stdout=%q stderr=%q", stdout, stderr)
+	t.Logf("srun output:\n%s", stdout)
+
+	// Verify all 3 ranks reported in.
+	assert.Contains(t, stdout, "rank 0 of 3 on worker-")
+	assert.Contains(t, stdout, "rank 1 of 3 on worker-")
+	assert.Contains(t, stdout, "rank 2 of 3 on worker-")
+}

--- a/cmd/sind/mpi_test.go
+++ b/cmd/sind/mpi_test.go
@@ -52,7 +52,7 @@ func TestMPI(t *testing.T) {
 	stdout, stderr, err := executeWithRealmCtx(ctx, realm, "exec", "--", "ompi_info", "--all")
 	require.NoError(t, err, "ompi_info: stderr=%q", stderr)
 	assert.Contains(t, stdout, "Open MPI")
-	assert.Contains(t, stdout, "MCA pmix")
+	assert.Contains(t, stdout, "--with-pmix")
 	assert.Contains(t, stdout, "MCA pml: ucx")
 	t.Logf("ompi_info output:\n%s", stdout)
 

--- a/cmd/sind/mpi_test.go
+++ b/cmd/sind/mpi_test.go
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
 	require.NoError(t, err, "mpicc: stderr=%q", stderr)
 
 	// Run across all 3 workers with one task per node.
-	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "--", "srun", "-N3", "--ntasks-per-node=1", "--mpi=pmix", "./hello_mpi")
+	stdout, stderr, err = executeWithRealmCtx(ctx, realm, "exec", "--", "srun", "-N3", "--ntasks-per-node=1", "./hello_mpi")
 	require.NoError(t, err, "srun mpi: stdout=%q stderr=%q", stdout, stderr)
 	t.Logf("srun output:\n%s", stdout)
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,15 +8,32 @@ variable "IMAGE_NAME" {
   default = "sind-node"
 }
 
-# Must match the ARG SLURM_VERSION in the Dockerfile. Pinned here because the
-# Dockerfile checksum is coupled to this exact version.
+# Must match the ARG defaults in the Dockerfile. Pinned here because the
+# Dockerfile checksums are coupled to these exact versions.
 variable "SLURM_VERSION" {
   default = "25.11.4"
+}
+
+variable "UCX_VERSION" {
+  default = "1.20.0"
+}
+
+variable "PMIX_VERSION" {
+  default = "6.1.0"
+}
+
+variable "PRRTE_VERSION" {
+  default = "4.1.0"
+}
+
+variable "OMPI_VERSION" {
+  default = "5.0.10"
 }
 
 target "default" {
   context    = "."
   dockerfile = "Dockerfile"
+  network    = "host"
   tags = [
     "${REGISTRY}/${IMAGE_NAME}:${SLURM_VERSION}",
   ]

--- a/docs/content/container-images/_index.md
+++ b/docs/content/container-images/_index.md
@@ -5,4 +5,4 @@ icon: "deployed_code"
 description: "Building and customizing sind node images"
 ---
 
-sind runs each Slurm node as a Docker container. This section covers the default image and how to build custom images.
+sind runs each Slurm node as a Docker container. The default image includes Slurm with PMIx support and a full OpenMPI stack (UCX, PMIx, PRRTE, OpenMPI), all compiled from source. This section covers the default image and how to build custom images.

--- a/docs/content/container-images/building-images.md
+++ b/docs/content/container-images/building-images.md
@@ -20,8 +20,10 @@ This is the default image when `defaults.image` is not specified.
 The default image:
 
 - Is based on Rocky Linux 10
-- Builds Slurm from source
-- Contains all daemons (slurmctld, slurmd, munge, sshd)
+- Builds Slurm, OpenMPI, PMIx, PRRTE, and UCX from source
+- Contains all Slurm daemons (slurmctld, slurmd, munge, sshd) and a full MPI stack
+- Slurm is built with PMIx support (`--with-pmix`) for native PMIx job launch
+- OpenMPI is built with external PMIx, PRRTE, UCX, hwloc, and libevent
 - Uses systemd as init (PID 1)
 
 sind enables the appropriate Slurm services based on node role at container start.

--- a/docs/content/guides/_index.md
+++ b/docs/content/guides/_index.md
@@ -1,0 +1,8 @@
+---
+weight: 350
+title: "Guides"
+icon: "menu_book"
+description: "Task-oriented walkthroughs for common workflows"
+---
+
+Applied guides that show how to use sind for specific tasks and integrations.

--- a/docs/content/guides/ci-cd.md
+++ b/docs/content/guides/ci-cd.md
@@ -1,5 +1,5 @@
 ---
-weight: 380
+weight: 353
 title: "CI/CD"
 icon: "deployed_code"
 description: "Using sind in GitHub Actions and other CI systems"

--- a/docs/content/guides/mcp.md
+++ b/docs/content/guides/mcp.md
@@ -1,5 +1,5 @@
 ---
-weight: 370
+weight: 352
 title: "MCP Integration"
 description: "Using sind with AI assistants via the Model Context Protocol"
 ---

--- a/docs/content/guides/mpi-jobs.md
+++ b/docs/content/guides/mpi-jobs.md
@@ -1,0 +1,103 @@
+---
+weight: 351
+title: "Running MPI Jobs"
+icon: "hub"
+description: "Compile and run multi-node MPI programs with OpenMPI and PMIx"
+toc: true
+---
+
+The default sind-node image ships with a full MPI stack (OpenMPI, PMIx, PRRTE, UCX) and Slurm configured with `MpiDefault=pmix`. This guide walks through compiling and running a simple MPI program across multiple nodes.
+
+## Create a multi-node cluster
+
+Create a cluster with 3 workers:
+
+```bash
+sind create cluster <<'EOF'
+kind: Cluster
+nodes:
+  - controller
+  - worker: 3
+EOF
+```
+
+## Verify the MPI stack
+
+Check that OpenMPI is installed and configured with PMIx and UCX:
+
+```bash
+sind exec -- ompi_info | grep -E "Open MPI:|MCA pml|with-pmix"
+```
+
+You should see OpenMPI's version, the UCX point-to-point layer, and `--with-pmix` in the configure line.
+
+## Write an MPI program
+
+Create a hello-world program that synchronizes all ranks with a barrier:
+
+```bash
+sind exec -- sh -c 'cat > hello_mpi.c << "CSRC"
+#include <mpi.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(int argc, char **argv) {
+    MPI_Init(&argc, &argv);
+
+    int rank, size;
+    char hostname[256];
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    gethostname(hostname, sizeof(hostname));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    printf("rank %d of %d on %s\n", rank, size, hostname);
+
+    MPI_Finalize();
+    return 0;
+}
+CSRC'
+```
+
+## Compile
+
+The image includes `mpicc`, which wraps gcc with the correct MPI flags:
+
+```bash
+sind exec -- mpicc -o hello_mpi hello_mpi.c
+```
+
+## Run across all nodes
+
+Launch one task per worker node via `srun`:
+
+```bash
+sind exec -- srun -N3 --ntasks-per-node=1 ./hello_mpi
+```
+
+Expected output (order may vary):
+
+```
+rank 0 of 3 on worker-0
+rank 1 of 3 on worker-1
+rank 2 of 3 on worker-2
+```
+
+Since `MpiDefault=pmix` is set in the generated `slurm.conf`, `srun` uses PMIx for process launch automatically — no `--mpi=pmix` flag needed.
+
+## Batch submission
+
+The same program works with `sbatch`:
+
+```bash
+sind exec -- sh -c 'cat > mpi_job.sh << "SCRIPT"
+#!/bin/sh
+#SBATCH --job-name=mpi-hello
+#SBATCH --nodes=3
+#SBATCH --ntasks-per-node=1
+srun hello_mpi
+SCRIPT'
+
+sind exec -- sbatch --wait mpi_job.sh
+sind exec -- sh -c 'cat slurm-*.out'
+```

--- a/pkg/slurm/config.go
+++ b/pkg/slurm/config.go
@@ -52,6 +52,7 @@ func GenerateSlurmConf(clusterName string, main config.Section) string {
 	b.WriteString("\n")
 	b.WriteString("ProctrackType=proctrack/cgroup\n")
 	b.WriteString("TaskPlugin=task/cgroup,task/affinity\n")
+	b.WriteString("MpiDefault=pmix\n")
 	b.WriteString("ReturnToService=2\n")
 	b.WriteString("PlugStackConfig=" + ConfDir + "/plugstack.conf\n")
 	b.WriteString("\n")

--- a/pkg/slurm/config_test.go
+++ b/pkg/slurm/config_test.go
@@ -17,6 +17,7 @@ func TestGenerateSlurmConf(t *testing.T) {
 	assert.Contains(t, conf, "SlurmctldHost=controller")
 	assert.Contains(t, conf, "ProctrackType=proctrack/cgroup")
 	assert.Contains(t, conf, "TaskPlugin=task/cgroup,task/affinity")
+	assert.Contains(t, conf, "MpiDefault=pmix")
 	assert.Contains(t, conf, "ReturnToService=2")
 	assert.Contains(t, conf, "include /etc/slurm/sind-nodes.conf")
 	assert.Contains(t, conf, "PlugStackConfig=/etc/slurm/plugstack.conf")


### PR DESCRIPTION
Closes #25

Build the full MPI stack (UCX 1.20.0, PMIx 6.1.0, PRRTE 4.1.0, OpenMPI 5.0.10) from source in the sind-node image using multi-stage Dockerfile builds. Slurm is rebuilt with `--with-pmix` for native PMIx job launch.

- add UCX, PMIx, PRRTE, OpenMPI builder stages with shared builder-base
- include gcc in runtime image for mpicc wrapper compiler
- set `MpiDefault=pmix` in generated slurm.conf
- add MPI integration test: compile and srun hello-world across 3 workers
- add Guides docs section, move CI/CD and MCP there, add MPI jobs walkthrough
- build sind-node image in CI with GHA cache before integration tests