### PR TITLE
Support per-node capabilities and device access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -263,10 +263,12 @@ RUN ssh-keygen -A && \
 # depending on the node's role.
 RUN systemctl enable munge sshd
 
-# Mask units that are unnecessary or problematic inside a container
+# Mask units that are unnecessary or problematic inside a container.
+# Note: sys-fs-fuse-connections.mount is NOT masked — it is a no-op without
+# /dev/fuse and must remain unmasked for FUSE to work when containers are
+# granted SYS_ADMIN + /dev/fuse via capAdd/devices.
 RUN systemctl mask \
     dev-hugepages.mount \
-    sys-fs-fuse-connections.mount \
     getty.target \
     console-getty.service
 

--- a/cmd/sind/worker.go
+++ b/cmd/sind/worker.go
@@ -33,6 +33,10 @@ func newCreateWorkerCommand() *cobra.Command {
 	cmd.Flags().String("tmp-size", "", "/tmp tmpfs size")
 	cmd.Flags().Bool("unmanaged", false, "don't start slurmd, don't add to slurm.conf")
 	cmd.Flags().Bool("pull", false, "pull images before creating containers")
+	cmd.Flags().StringSlice("cap-add", nil, "add Linux capabilities (e.g. SYS_ADMIN)")
+	cmd.Flags().StringSlice("cap-drop", nil, "drop Linux capabilities")
+	cmd.Flags().StringSlice("device", nil, "host devices to expose (e.g. /dev/fuse)")
+	cmd.Flags().StringSlice("security-opt", nil, "security options")
 
 	return cmd
 }
@@ -45,6 +49,10 @@ func runCreateWorker(cmd *cobra.Command, clusterName string) error {
 	tmpSize, _ := cmd.Flags().GetString("tmp-size")
 	unmanaged, _ := cmd.Flags().GetBool("unmanaged")
 	pull, _ := cmd.Flags().GetBool("pull")
+	capAdd, _ := cmd.Flags().GetStringSlice("cap-add")
+	capDrop, _ := cmd.Flags().GetStringSlice("cap-drop")
+	devices, _ := cmd.Flags().GetStringSlice("device")
+	securityOpt, _ := cmd.Flags().GetStringSlice("security-opt")
 
 	opts := cluster.WorkerAddOptions{
 		ClusterName: clusterName,
@@ -55,6 +63,10 @@ func runCreateWorker(cmd *cobra.Command, clusterName string) error {
 		TmpSize:     tmpSize,
 		Unmanaged:   unmanaged,
 		Pull:        pull,
+		CapAdd:      capAdd,
+		CapDrop:     capDrop,
+		Devices:     devices,
+		SecurityOpt: securityOpt,
 	}
 
 	ctx := cmd.Context()

--- a/docs/content/configuration/cluster-config.md
+++ b/docs/content/configuration/cluster-config.md
@@ -93,6 +93,12 @@ The `defaults` section sets values inherited by all nodes unless overridden at t
 | `cpus` | `1` | CPU limit per container |
 | `memory` | `"512m"` | Memory limit per container |
 | `tmpSize` | `"256m"` | tmpfs size for `/tmp` |
+| `capAdd` | none | Extra Linux capabilities |
+| `capDrop` | none | Dropped Linux capabilities |
+| `devices` | none | Host devices to expose |
+| `securityOpt` | none | Extra security options |
+
+Scalar fields (`image`, `cpus`, `memory`, `tmpSize`) are overridden by per-node values. List fields (`capAdd`, `capDrop`, `devices`, `securityOpt`) are merged with per-node values.
 
 ## Storage section
 
@@ -163,3 +169,5 @@ See [Slurm Configuration]({{< relref "/architecture/slurm-config" >}}) for detai
 - `count` is only valid for worker nodes
 - `managed` is only valid for worker nodes
 - `count` must not be negative
+- `capAdd`/`capDrop` values must be recognized Linux capability names (e.g. `SYS_ADMIN`, `NET_ADMIN`, `ALL`)
+- `devices` paths must be absolute (start with `/`)

--- a/docs/content/configuration/node-definitions.md
+++ b/docs/content/configuration/node-definitions.md
@@ -24,8 +24,12 @@ toc: true
 | `tmpSize` | global + per-node | `"256m"` | tmpfs size for `/tmp` |
 | `count` | worker only | `1` | Number of worker nodes |
 | `managed` | worker only | `true` | Start slurmd and add to slurm.conf |
+| `capAdd` | global + per-node | none | Extra Linux capabilities (e.g. `SYS_ADMIN`) |
+| `capDrop` | global + per-node | none | Dropped Linux capabilities |
+| `devices` | global + per-node | none | Host devices to expose (e.g. `/dev/fuse`) |
+| `securityOpt` | global + per-node | none | Extra security options |
 
-Per-node values override the `defaults` section, which in turn overrides the built-in defaults.
+Per-node scalar values override the `defaults` section. Security list fields (`capAdd`, `capDrop`, `devices`, `securityOpt`) are **merged** with defaults rather than replacing them.
 
 ## Shorthand syntax
 
@@ -74,6 +78,48 @@ Unmanaged workers can also be created dynamically:
 
 ```bash
 sind create worker --count 2 --unmanaged
+```
+
+## Capabilities and devices
+
+sind's default security posture avoids extra capabilities and device access. When specific use cases require them (e.g. testing CVMFS provisioning or FUSE-based filesystems), you can grant targeted privileges per node.
+
+```yaml
+nodes:
+  - role: controller
+  - role: worker
+    count: 3
+    capAdd:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+```
+
+Capability names follow Docker convention (without the `CAP_` prefix). Device strings use Docker's format: `/dev/fuse` or `/dev/sda:/dev/xvda:rwm`.
+
+When set in the `defaults` section, security fields apply to all nodes. Per-node values merge with (not replace) defaults:
+
+```yaml
+defaults:
+  capAdd:
+    - SYS_ADMIN
+  devices:
+    - /dev/fuse
+
+nodes:
+  - role: controller
+  - role: worker
+    count: 3
+    capAdd:
+      - NET_ADMIN    # workers get both SYS_ADMIN and NET_ADMIN
+```
+
+sind logs a notice at cluster creation when extra privileges are configured, making the escalation visible.
+
+Workers created via `sind create worker` also support these fields:
+
+```bash
+sind create worker --cap-add SYS_ADMIN --device /dev/fuse
 ```
 
 ## Default nodes

--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -5,6 +5,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/GSI-HPC/sind/pkg/config"
@@ -25,6 +26,28 @@ func controllerImage(cfg *config.Cluster) string {
 		}
 	}
 	return config.DefaultImage
+}
+
+// logExtraPrivileges emits a notice for each node that has extra capabilities,
+// devices, or security options configured, making privilege escalation visible.
+func logExtraPrivileges(ctx context.Context, configs []RunConfig) {
+	log := sindlog.From(ctx)
+	for _, cfg := range configs {
+		if len(cfg.CapAdd) == 0 && len(cfg.Devices) == 0 && len(cfg.SecurityOpt) == 0 {
+			continue
+		}
+		var parts []string
+		if len(cfg.CapAdd) > 0 {
+			parts = append(parts, "capAdd=["+strings.Join(cfg.CapAdd, ",")+"]")
+		}
+		if len(cfg.Devices) > 0 {
+			parts = append(parts, "devices=["+strings.Join(cfg.Devices, ",")+"]")
+		}
+		if len(cfg.SecurityOpt) > 0 {
+			parts = append(parts, "securityOpt=["+strings.Join(cfg.SecurityOpt, ",")+"]")
+		}
+		log.InfoContext(ctx, "extra privileges", "node", cfg.ShortName, "config", strings.Join(parts, " "))
+	}
 }
 
 // nodeResult holds per-node data collected during concurrent setup.
@@ -109,6 +132,7 @@ func Create(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager, c
 	log.DebugContext(ctx, "cluster resources created")
 
 	nodeConfigs := NodeRunConfigs(cfg, realm, dnsIP, slurmVersion)
+	logExtraPrivileges(ctx, nodeConfigs)
 	if err := createAllNodes(ctx, client, meshMgr, nodeConfigs); err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/create_test.go
+++ b/pkg/cluster/create_test.go
@@ -974,6 +974,49 @@ func TestRegisterMesh_KnownHostError(t *testing.T) {
 	assert.Contains(t, err.Error(), "registering host key")
 }
 
+func TestLogExtraPrivileges(t *testing.T) {
+	t.Run("no privileges", func(t *testing.T) {
+		configs := []RunConfig{
+			{ShortName: "controller"},
+			{ShortName: "worker-0"},
+		}
+		// Should not panic or log anything.
+		logExtraPrivileges(t.Context(), configs)
+	})
+
+	t.Run("capAdd only", func(t *testing.T) {
+		configs := []RunConfig{
+			{ShortName: "worker-0", CapAdd: []string{"SYS_ADMIN"}},
+		}
+		logExtraPrivileges(t.Context(), configs)
+	})
+
+	t.Run("devices only", func(t *testing.T) {
+		configs := []RunConfig{
+			{ShortName: "worker-0", Devices: []string{"/dev/fuse"}},
+		}
+		logExtraPrivileges(t.Context(), configs)
+	})
+
+	t.Run("securityOpt only", func(t *testing.T) {
+		configs := []RunConfig{
+			{ShortName: "worker-0", SecurityOpt: []string{"apparmor=unconfined"}},
+		}
+		logExtraPrivileges(t.Context(), configs)
+	})
+
+	t.Run("all fields", func(t *testing.T) {
+		configs := []RunConfig{
+			{ShortName: "worker-0",
+				CapAdd:      []string{"SYS_ADMIN", "NET_ADMIN"},
+				Devices:     []string{"/dev/fuse"},
+				SecurityOpt: []string{"apparmor=unconfined"},
+			},
+		}
+		logExtraPrivileges(t.Context(), configs)
+	})
+}
+
 func TestEnableSlurm_ProbeTimeout(t *testing.T) {
 	var m mock.Executor
 	m.OnCall = func(args []string, _ string) mock.Result {

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -67,6 +67,10 @@ type RunConfig struct {
 	Managed         bool        // start slurmd and add to slurm.conf (worker only)
 	ContainerNumber int         // 1-based compose container instance number
 	Pull            bool        // force fresh image pull (--pull always)
+	CapAdd          []string    // extra Linux capabilities (e.g. "SYS_ADMIN")
+	CapDrop         []string    // dropped Linux capabilities
+	Devices         []string    // host devices to expose (e.g. "/dev/fuse")
+	SecurityOpt     []string    // extra security options
 }
 
 // BuildRunArgs returns the docker arguments for creating a node container.
@@ -128,6 +132,20 @@ func BuildRunArgs(cfg RunConfig) []string {
 		"--security-opt", "writable-cgroups=true",
 		"--security-opt", "label=disable",
 	)
+
+	// Extra capabilities and devices (opt-in)
+	for _, cap := range cfg.CapAdd {
+		args = append(args, "--cap-add", cap)
+	}
+	for _, cap := range cfg.CapDrop {
+		args = append(args, "--cap-drop", cap)
+	}
+	for _, dev := range cfg.Devices {
+		args = append(args, "--device", dev)
+	}
+	for _, opt := range cfg.SecurityOpt {
+		args = append(args, "--security-opt", opt)
+	}
 
 	// Labels
 	labels := NodeLabels(cfg.Realm, cfg.ClusterName, cfg.Role, cfg.SlurmVersion, cfg.DataHostPath, cfg.ContainerNumber)
@@ -206,6 +224,10 @@ func NodeRunConfigs(cfg *config.Cluster, realm, dnsIP, slurmVersion string) []Ru
 				DataMountPath:   dataMountPath,
 				ContainerNumber: 1,
 				Pull:            cfg.Pull,
+				CapAdd:          n.CapAdd,
+				CapDrop:         n.CapDrop,
+				Devices:         n.Devices,
+				SecurityOpt:     n.SecurityOpt,
 			})
 		case config.RoleWorker:
 			count := n.Count
@@ -230,6 +252,10 @@ func NodeRunConfigs(cfg *config.Cluster, realm, dnsIP, slurmVersion string) []Ru
 					Managed:         isManaged,
 					ContainerNumber: workerIdx + 1,
 					Pull:            cfg.Pull,
+					CapAdd:          n.CapAdd,
+					CapDrop:         n.CapDrop,
+					Devices:         n.Devices,
+					SecurityOpt:     n.SecurityOpt,
 				})
 				workerIdx++
 			}

--- a/pkg/cluster/node_test.go
+++ b/pkg/cluster/node_test.go
@@ -698,3 +698,94 @@ func TestEnableSlurmServices_Error(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "enabling slurmctld on controller")
 }
+
+// --- Security fields in BuildRunArgs ---
+
+func TestBuildRunArgs_CapAdd(t *testing.T) {
+	cfg := defaultRunConfig()
+	cfg.CapAdd = []string{"SYS_ADMIN", "NET_ADMIN"}
+	args := BuildRunArgs(cfg)
+
+	caps := testutil.ArgValues(args, "--cap-add")
+	assert.Equal(t, []string{"SYS_ADMIN", "NET_ADMIN"}, caps)
+}
+
+func TestBuildRunArgs_CapDrop(t *testing.T) {
+	cfg := defaultRunConfig()
+	cfg.CapDrop = []string{"MKNOD"}
+	args := BuildRunArgs(cfg)
+
+	caps := testutil.ArgValues(args, "--cap-drop")
+	assert.Equal(t, []string{"MKNOD"}, caps)
+}
+
+func TestBuildRunArgs_Devices(t *testing.T) {
+	cfg := defaultRunConfig()
+	cfg.Devices = []string{"/dev/fuse", "/dev/sda:/dev/xvda:rwm"}
+	args := BuildRunArgs(cfg)
+
+	devs := testutil.ArgValues(args, "--device")
+	assert.Equal(t, []string{"/dev/fuse", "/dev/sda:/dev/xvda:rwm"}, devs)
+}
+
+func TestBuildRunArgs_SecurityOptExtra(t *testing.T) {
+	cfg := defaultRunConfig()
+	cfg.SecurityOpt = []string{"apparmor=unconfined"}
+	args := BuildRunArgs(cfg)
+
+	secOpts := testutil.ArgValues(args, "--security-opt")
+	// Should contain both the built-in opts and the extra one
+	assert.Contains(t, secOpts, "writable-cgroups=true")
+	assert.Contains(t, secOpts, "label=disable")
+	assert.Contains(t, secOpts, "apparmor=unconfined")
+}
+
+func TestBuildRunArgs_NoSecurityFieldsByDefault(t *testing.T) {
+	cfg := defaultRunConfig()
+	args := BuildRunArgs(cfg)
+
+	// No --cap-add, --cap-drop, or --device flags
+	caps := testutil.ArgValues(args, "--cap-add")
+	assert.Empty(t, caps)
+
+	drops := testutil.ArgValues(args, "--cap-drop")
+	assert.Empty(t, drops)
+
+	devs := testutil.ArgValues(args, "--device")
+	assert.Empty(t, devs)
+
+	// Only the built-in security opts
+	secOpts := testutil.ArgValues(args, "--security-opt")
+	assert.Equal(t, []string{"writable-cgroups=true", "label=disable"}, secOpts)
+}
+
+// --- Security fields in NodeRunConfigs ---
+
+func TestNodeRunConfigs_SecurityFields(t *testing.T) {
+	cfg := &config.Cluster{
+		Name: "dev",
+		Nodes: []config.Node{
+			{Role: config.RoleController, Image: "img:1", CPUs: 2, Memory: "2g", TmpSize: "1g",
+				CapAdd: []string{"SYS_ADMIN"}, Devices: []string{"/dev/fuse"}},
+			{Role: config.RoleWorker, Count: 2, Image: "img:1", CPUs: 2, Memory: "2g", TmpSize: "1g",
+				CapAdd: []string{"NET_ADMIN"}, CapDrop: []string{"MKNOD"},
+				Devices: []string{"/dev/sda"}, SecurityOpt: []string{"apparmor=unconfined"}},
+		},
+	}
+
+	configs := NodeRunConfigs(cfg, mesh.DefaultRealm, "172.18.0.2", "25.11.0")
+
+	require.Len(t, configs, 3)
+
+	// Controller
+	assert.Equal(t, []string{"SYS_ADMIN"}, configs[0].CapAdd)
+	assert.Equal(t, []string{"/dev/fuse"}, configs[0].Devices)
+
+	// Workers inherit from their node config
+	for _, wc := range configs[1:] {
+		assert.Equal(t, []string{"NET_ADMIN"}, wc.CapAdd)
+		assert.Equal(t, []string{"MKNOD"}, wc.CapDrop)
+		assert.Equal(t, []string{"/dev/sda"}, wc.Devices)
+		assert.Equal(t, []string{"apparmor=unconfined"}, wc.SecurityOpt)
+	}
+}

--- a/pkg/cluster/worker.go
+++ b/pkg/cluster/worker.go
@@ -28,6 +28,10 @@ type WorkerAddOptions struct {
 	TmpSize     string
 	Unmanaged   bool
 	Pull        bool
+	CapAdd      []string
+	CapDrop     []string
+	Devices     []string
+	SecurityOpt []string
 }
 
 // --- Exported functions ---
@@ -124,6 +128,10 @@ func WorkerAdd(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager
 			Managed:         !opts.Unmanaged,
 			ContainerNumber: startIdx + i + 1,
 			Pull:            opts.Pull,
+			CapAdd:          opts.CapAdd,
+			CapDrop:         opts.CapDrop,
+			Devices:         opts.Devices,
+			SecurityOpt:     opts.SecurityOpt,
 		}
 	}
 

--- a/pkg/config/capability.go
+++ b/pkg/config/capability.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package config
+
+// validCapabilities lists all Linux capabilities recognized by Docker.
+// Names follow Docker convention (without the CAP_ prefix).
+// See capabilities(7) and https://docs.docker.com/reference/cli/docker/container/run/#privileged
+var validCapabilities = map[string]struct{}{
+	"ALL":                {},
+	"AUDIT_CONTROL":      {},
+	"AUDIT_READ":         {},
+	"AUDIT_WRITE":        {},
+	"BLOCK_SUSPEND":      {},
+	"BPF":                {},
+	"CHECKPOINT_RESTORE": {},
+	"CHOWN":              {},
+	"DAC_OVERRIDE":       {},
+	"DAC_READ_SEARCH":    {},
+	"FOWNER":             {},
+	"FSETID":             {},
+	"IPC_LOCK":           {},
+	"IPC_OWNER":          {},
+	"KILL":               {},
+	"LEASE":              {},
+	"LINUX_IMMUTABLE":    {},
+	"MAC_ADMIN":          {},
+	"MAC_OVERRIDE":       {},
+	"MKNOD":              {},
+	"NET_ADMIN":          {},
+	"NET_BIND_SERVICE":   {},
+	"NET_BROADCAST":      {},
+	"NET_RAW":            {},
+	"PERFMON":            {},
+	"SETFCAP":            {},
+	"SETGID":             {},
+	"SETPCAP":            {},
+	"SETUID":             {},
+	"SYS_ADMIN":          {},
+	"SYS_BOOT":           {},
+	"SYS_CHROOT":         {},
+	"SYS_MODULE":         {},
+	"SYS_NICE":           {},
+	"SYS_PACCT":          {},
+	"SYS_PTRACE":         {},
+	"SYS_RAWIO":          {},
+	"SYS_RESOURCE":       {},
+	"SYS_TIME":           {},
+	"SYS_TTY_CONFIG":     {},
+	"SYSLOG":             {},
+	"WAKE_ALARM":         {},
+}
+
+// isValidCapability reports whether name is a recognized Linux capability.
+func isValidCapability(name string) bool {
+	_, ok := validCapabilities[name]
+	return ok
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,10 +16,14 @@ import (
 
 // Defaults holds default settings applied to all nodes unless overridden.
 type Defaults struct {
-	Image   string `json:"image,omitempty"`
-	CPUs    int    `json:"cpus,omitempty"`
-	Memory  string `json:"memory,omitempty"`
-	TmpSize string `json:"tmpSize,omitempty"`
+	Image       string   `json:"image,omitempty"`
+	CPUs        int      `json:"cpus,omitempty"`
+	Memory      string   `json:"memory,omitempty"`
+	TmpSize     string   `json:"tmpSize,omitempty"`
+	CapAdd      []string `json:"capAdd,omitempty"`
+	CapDrop     []string `json:"capDrop,omitempty"`
+	Devices     []string `json:"devices,omitempty"`
+	SecurityOpt []string `json:"securityOpt,omitempty"`
 }
 
 // Role identifies the function of a node within a cluster.
@@ -34,13 +38,17 @@ const (
 
 // Node represents a single node or node group in the cluster configuration.
 type Node struct {
-	Role    Role   `json:"role"`
-	Count   int    `json:"count,omitempty"`
-	Image   string `json:"image,omitempty"`
-	CPUs    int    `json:"cpus,omitempty"`
-	Memory  string `json:"memory,omitempty"`
-	TmpSize string `json:"tmpSize,omitempty"`
-	Managed *bool  `json:"managed,omitempty"`
+	Role        Role     `json:"role"`
+	Count       int      `json:"count,omitempty"`
+	Image       string   `json:"image,omitempty"`
+	CPUs        int      `json:"cpus,omitempty"`
+	Memory      string   `json:"memory,omitempty"`
+	TmpSize     string   `json:"tmpSize,omitempty"`
+	Managed     *bool    `json:"managed,omitempty"`
+	CapAdd      []string `json:"capAdd,omitempty"`
+	CapDrop     []string `json:"capDrop,omitempty"`
+	Devices     []string `json:"devices,omitempty"`
+	SecurityOpt []string `json:"securityOpt,omitempty"`
 }
 
 // UnmarshalJSON supports three YAML forms:
@@ -241,7 +249,35 @@ func (c *Cluster) ApplyDefaults() {
 		if c.Nodes[i].TmpSize == "" {
 			c.Nodes[i].TmpSize = tmpSize
 		}
+		// Security fields: per-node values merge with (not replace) defaults
+		c.Nodes[i].CapAdd = mergeStringSlices(c.Defaults.CapAdd, c.Nodes[i].CapAdd)
+		c.Nodes[i].CapDrop = mergeStringSlices(c.Defaults.CapDrop, c.Nodes[i].CapDrop)
+		c.Nodes[i].Devices = mergeStringSlices(c.Defaults.Devices, c.Nodes[i].Devices)
+		c.Nodes[i].SecurityOpt = mergeStringSlices(c.Defaults.SecurityOpt, c.Nodes[i].SecurityOpt)
 	}
+}
+
+// mergeStringSlices merges two string slices, deduplicating entries.
+// Returns nil if both inputs are empty.
+func mergeStringSlices(base, overlay []string) []string {
+	if len(base) == 0 && len(overlay) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(base)+len(overlay))
+	var result []string
+	for _, s := range base {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			result = append(result, s)
+		}
+	}
+	for _, s := range overlay {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			result = append(result, s)
+		}
+	}
+	return result
 }
 
 // Validate checks that the cluster configuration satisfies all constraints.
@@ -279,6 +315,25 @@ func (c *Cluster) Validate() error {
 	}
 	if workers < 1 {
 		return fmt.Errorf("at least one worker node required, got %d", workers)
+	}
+
+	for _, n := range c.Nodes {
+		for _, cap := range n.CapAdd {
+			if !isValidCapability(cap) {
+				return fmt.Errorf("unknown capability %q in capAdd", cap)
+			}
+		}
+		for _, cap := range n.CapDrop {
+			if !isValidCapability(cap) {
+				return fmt.Errorf("unknown capability %q in capDrop", cap)
+			}
+		}
+		for _, dev := range n.Devices {
+			hostDev := strings.SplitN(dev, ":", 2)[0]
+			if !strings.HasPrefix(hostDev, "/") {
+				return fmt.Errorf("device path must be absolute, got %q", dev)
+			}
+		}
 	}
 
 	sections := []struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -839,3 +839,191 @@ func TestValidate_SlurmSections(t *testing.T) {
 		require.NoError(t, cfg.Validate())
 	})
 }
+
+// --- Security fields: capAdd, capDrop, devices, securityOpt ---
+
+func TestParse_SecurityFields(t *testing.T) {
+	input := `kind: Cluster
+nodes:
+  - role: controller
+  - role: worker
+    count: 3
+    capAdd:
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse`
+
+	cfg, err := Parse([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, cfg.Nodes, 2)
+
+	assert.Empty(t, cfg.Nodes[0].CapAdd)
+	assert.Equal(t, []string{"SYS_ADMIN"}, cfg.Nodes[1].CapAdd)
+	assert.Equal(t, []string{"/dev/fuse"}, cfg.Nodes[1].Devices)
+}
+
+func TestParse_SecurityFieldsAllFields(t *testing.T) {
+	input := `kind: Cluster
+nodes:
+  - role: controller
+  - role: worker
+    capAdd:
+      - SYS_ADMIN
+      - NET_ADMIN
+    capDrop:
+      - MKNOD
+    devices:
+      - /dev/fuse
+      - /dev/sda:/dev/xvda:rwm
+    securityOpt:
+      - apparmor=unconfined`
+
+	cfg, err := Parse([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, cfg.Nodes, 2)
+
+	w := cfg.Nodes[1]
+	assert.Equal(t, []string{"SYS_ADMIN", "NET_ADMIN"}, w.CapAdd)
+	assert.Equal(t, []string{"MKNOD"}, w.CapDrop)
+	assert.Equal(t, []string{"/dev/fuse", "/dev/sda:/dev/xvda:rwm"}, w.Devices)
+	assert.Equal(t, []string{"apparmor=unconfined"}, w.SecurityOpt)
+}
+
+func TestParse_SecurityFieldsInDefaults(t *testing.T) {
+	input := `kind: Cluster
+defaults:
+  capAdd:
+    - SYS_ADMIN
+  devices:
+    - /dev/fuse
+nodes:
+  - role: controller
+  - role: worker`
+
+	cfg, err := Parse([]byte(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"SYS_ADMIN"}, cfg.Defaults.CapAdd)
+	assert.Equal(t, []string{"/dev/fuse"}, cfg.Defaults.Devices)
+}
+
+func TestApplyDefaults_SecurityFieldsMerge(t *testing.T) {
+	cfg := &Cluster{
+		Kind: "Cluster",
+		Name: "default",
+		Defaults: Defaults{
+			CapAdd:  []string{"SYS_ADMIN"},
+			Devices: []string{"/dev/fuse"},
+		},
+		Nodes: []Node{
+			{Role: RoleController},
+			{Role: RoleWorker, CapAdd: []string{"NET_ADMIN"}, Devices: []string{"/dev/sda"}},
+		},
+	}
+	cfg.ApplyDefaults()
+
+	// Controller inherits defaults only
+	assert.Equal(t, []string{"SYS_ADMIN"}, cfg.Nodes[0].CapAdd)
+	assert.Equal(t, []string{"/dev/fuse"}, cfg.Nodes[0].Devices)
+
+	// Worker merges defaults + per-node
+	assert.Equal(t, []string{"SYS_ADMIN", "NET_ADMIN"}, cfg.Nodes[1].CapAdd)
+	assert.Equal(t, []string{"/dev/fuse", "/dev/sda"}, cfg.Nodes[1].Devices)
+}
+
+func TestApplyDefaults_SecurityFieldsMergeDeduplicate(t *testing.T) {
+	cfg := &Cluster{
+		Kind: "Cluster",
+		Name: "default",
+		Defaults: Defaults{
+			CapAdd: []string{"SYS_ADMIN"},
+		},
+		Nodes: []Node{
+			{Role: RoleController},
+			{Role: RoleWorker, CapAdd: []string{"SYS_ADMIN", "NET_ADMIN"}},
+		},
+	}
+	cfg.ApplyDefaults()
+
+	// Duplicate SYS_ADMIN from defaults + node should be deduplicated
+	assert.Equal(t, []string{"SYS_ADMIN", "NET_ADMIN"}, cfg.Nodes[1].CapAdd)
+}
+
+func TestApplyDefaults_SecurityFieldsEmpty(t *testing.T) {
+	cfg := &Cluster{
+		Kind: "Cluster",
+		Name: "default",
+		Nodes: []Node{
+			{Role: RoleController},
+			{Role: RoleWorker},
+		},
+	}
+	cfg.ApplyDefaults()
+
+	// No security fields set — should remain nil
+	assert.Nil(t, cfg.Nodes[0].CapAdd)
+	assert.Nil(t, cfg.Nodes[0].CapDrop)
+	assert.Nil(t, cfg.Nodes[0].Devices)
+	assert.Nil(t, cfg.Nodes[0].SecurityOpt)
+}
+
+func TestValidate_SecurityFields(t *testing.T) {
+	base := func() *Cluster {
+		return &Cluster{
+			Kind: "Cluster",
+			Name: "default",
+			Nodes: []Node{
+				{Role: "controller"},
+				{Role: "worker"},
+			},
+		}
+	}
+
+	t.Run("valid capabilities", func(t *testing.T) {
+		cfg := base()
+		cfg.Nodes[1].CapAdd = []string{"SYS_ADMIN", "NET_ADMIN"}
+		cfg.Nodes[1].CapDrop = []string{"MKNOD"}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("ALL capability", func(t *testing.T) {
+		cfg := base()
+		cfg.Nodes[1].CapAdd = []string{"ALL"}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("invalid capAdd", func(t *testing.T) {
+		cfg := base()
+		cfg.Nodes[1].CapAdd = []string{"INVALID_CAP"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown capability "INVALID_CAP" in capAdd`)
+	})
+
+	t.Run("invalid capDrop", func(t *testing.T) {
+		cfg := base()
+		cfg.Nodes[1].CapDrop = []string{"NOT_A_CAP"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `unknown capability "NOT_A_CAP" in capDrop`)
+	})
+
+	t.Run("valid devices", func(t *testing.T) {
+		cfg := base()
+		cfg.Nodes[1].Devices = []string{"/dev/fuse", "/dev/sda:/dev/xvda:rwm"}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("device path not absolute", func(t *testing.T) {
+		cfg := base()
+		cfg.Nodes[1].Devices = []string{"dev/fuse"}
+		err := cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "device path must be absolute")
+	})
+
+	t.Run("valid security opts", func(t *testing.T) {
+		cfg := base()
+		cfg.Nodes[1].SecurityOpt = []string{"apparmor=unconfined"}
+		require.NoError(t, cfg.Validate())
+	})
+}


### PR DESCRIPTION
Add opt-in security fields (`capAdd`, `capDrop`, `devices`, `securityOpt`) to the cluster configuration, allowing users to grant specific Linux capabilities and expose host devices to individual containers.

The immediate motivation is testing CVMFS config management (package installation, autofs/automount setup, FUSE mount lifecycle) inside sind containers, but the feature is general-purpose.

sind's default security posture remains unchanged — no extra capabilities, no device access. These fields exist only for users who explicitly need them.

- Add fields to `Node` and `Defaults` structs with merge semantics (per-node merges with defaults, deduplicated)
- Validate capability names against known Linux capabilities allowlist
- Validate device paths are absolute
- Generate `--cap-add`, `--cap-drop`, `--device`, `--security-opt` docker flags in `BuildRunArgs()`
- Log info-level notice when extra privileges are configured
- Add `--cap-add`, `--cap-drop`, `--device`, `--security-opt` CLI flags to `sind create worker`
- Unmask `sys-fs-fuse-connections.mount` in Dockerfile so FUSE works when `SYS_ADMIN` + `/dev/fuse` are granted

Closes #39