### PR TITLE
Event-driven readiness monitoring and create pipeline optimizations

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -7,6 +7,13 @@ threshold:
   package: 50
   total: 80
 
+exclude:
+  paths:
+    # stream.go and exec.go use real os/exec and can only be covered by
+    # integration tests. logging.go is fully unit-testable and stays in.
+    - pkg/cmdexec/stream\.go
+    - pkg/cmdexec/exec\.go
+
 override:
   - path: ^pkg/
     threshold: 100

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,6 +10,7 @@ A CLI tool for running local Slurm clusters using Docker containers, inspired by
 
 - Linux host with cgroupv2 and `nsdelegate` mount option (`mount -o remount,nsdelegate /sys/fs/cgroup`)
 - Docker Engine 28.0+ (required for `--security-opt writable-cgroups=true`)
+- For clusters with 10+ nodes: `fs.inotify.max_user_instances >= 1024` (default 128 is too low)
 
 ## Supported Versions
 
@@ -42,18 +43,29 @@ sind creates cluster resources in a specific order to ensure dependencies are av
 3. Create `sind-ssh-config` volume and generate keypair (if not exists)
 4. Start `sind-ssh` container (if not exists)
 
-**Phase 2: Cluster Resources**
-1. Create cluster network (`sind-<cluster>-net`)
-2. Create cluster volumes (config, munge, data)
-3. Generate munge key and Slurm configuration
+**Phase 2: Cluster Resources** (concurrent pipelines, no barriers)
+1. Create cluster network
+2. Create config volume → write Slurm configuration
+3. Create munge volume → generate and write munge key
+4. Create data volume (if needed)
 
 **Phase 3: Node Containers**
-1. Start all node containers in parallel
-2. Wait for each node to become ready
+1. Create and start each node container in parallel
+2. Start per-node systemd D-Bus monitor immediately after each container starts
+3. Wait for each node to become ready, accelerated by events
 
-Node containers start in parallel because the global infrastructure (DNS, SSH) is already available. Slurm daemons handle transient connection failures during cluster bootstrap.
+There is no barrier between node creation and readiness probing — each node's goroutine creates its container, starts a systemd monitor, and begins probing in a single pipeline. This allows early-starting nodes to be probed while later nodes are still being created.
 
-sind waits for each node to become ready before returning success:
+#### Event-Driven Readiness
+
+sind uses two event sources to accelerate readiness detection:
+
+- **Docker events** — a single `docker events` stream watches all cluster containers for start/die events
+- **Systemd D-Bus monitors** — per-node `busctl monitor --watch-bind=yes` streams watch for unit state changes (e.g., sshd.service becoming active)
+
+When an event arrives, readiness probes re-evaluate immediately instead of waiting for the next poll tick. If the event sources are unavailable, sind falls back to poll-only mode transparently.
+
+#### Readiness Checks
 
 | Check | Description |
 |-------|-------------|
@@ -64,6 +76,10 @@ sind waits for each node to become ready before returning success:
 | slurmd ready | slurmd service active (worker only) |
 
 If any node fails to become ready within the timeout, `sind create cluster` fails and reports which nodes/checks failed. Partial clusters are not automatically cleaned up—use `sind delete cluster` to remove.
+
+**Phase 4: Mesh Registration and Slurm** (concurrent)
+
+After all nodes are ready, sind runs mesh registration (batch DNS + known_hosts) and Slurm enablement concurrently. This is safe because Slurm uses short hostnames (`controller`, `worker-0`) resolved by Docker's embedded DNS on the cluster network. The mesh DNS records (`*.cluster.realm.sind`) are only used for SSH relay access and host-side resolution.
 
 ### Design Goals
 

--- a/docs/content/architecture/overview.md
+++ b/docs/content/architecture/overview.md
@@ -41,24 +41,27 @@ PreflightCheck
       │
 resolveInfra        DNS IP │ SSH key │ Slurm version
       │
-createResources     network │ volumes → config │ munge
+createResources     network ║ (config vol → write) ║ (munge vol → write)
       │
-createAllNodes      node₁ │ node₂ │ ... │ nodeₙ
+setupNodes          (create + wait + SSH + hostkey) per node
       │
-setupNodes          (wait + SSH + hostkey) per node
-      │
-registerMesh        DNS records + known_hosts
-      │
-enableSlurm         (enable + probe) per eligible node
+registerMesh ║ enableSlurm
       │
   *Cluster
 ```
 
-Nodes start in parallel because the global infrastructure (DNS, SSH) is already available. Slurm daemons handle transient connection failures during bootstrap.
+Each node is created, monitored, and probed in a single pipeline — no barrier between node creation and readiness checking. Early-starting nodes begin probing while later nodes are still being created.
+
+Mesh registration (batch DNS + known_hosts) and Slurm enablement run concurrently after all nodes are ready.
 
 ## Readiness probes
 
-sind waits for each node to become ready before returning success:
+sind waits for each node to become ready before returning success. Probes are accelerated by two event sources:
+
+- **Docker events** — a single `docker events` stream watches all cluster containers for start/die events
+- **Systemd D-Bus monitors** — per-node `busctl monitor --watch-bind=yes` streams watch for unit state changes (e.g., sshd.service becoming active)
+
+When an event arrives, probes re-evaluate immediately instead of waiting for the next poll tick. If event sources are unavailable, sind falls back to poll-only mode.
 
 | Check | Description |
 |-------|-------------|

--- a/docs/content/troubleshooting/_index.md
+++ b/docs/content/troubleshooting/_index.md
@@ -1,0 +1,8 @@
+---
+weight: 550
+title: "Troubleshooting"
+icon: "build"
+description: "Common issues and solutions"
+---
+
+Solutions for common problems when running sind clusters.

--- a/docs/content/troubleshooting/container-exit-255.md
+++ b/docs/content/troubleshooting/container-exit-255.md
@@ -1,0 +1,51 @@
+---
+weight: 100
+title: "Container exits with code 255"
+---
+
+## Symptom
+
+Cluster creation fails with containers exiting immediately:
+
+```
+waiting for worker-5: container sind-dev-worker-5 is exited (exit code 255)
+```
+
+This typically happens when creating clusters with many nodes (8+). Some containers start successfully while others crash within the first second.
+
+## Cause
+
+Exit code 255 means systemd (PID 1 inside the container) failed during early initialization. The most common cause is the Linux `inotify` instance limit being too low.
+
+Each Docker container consumes several `inotify` file descriptors through containerd's cgroup event monitoring. systemd inside the container also requires inotify for service management. When the per-user limit is exhausted, new containers cannot initialize systemd and exit immediately with code 255.
+
+The default on many distributions (Fedora, Ubuntu) is 128 instances, which supports roughly 10-13 concurrent systemd containers depending on the workload.
+
+## Diagnosis
+
+Check the current limit and whether containerd is hitting it:
+
+```bash
+# Current limit
+cat /proc/sys/fs/inotify/max_user_instances
+# 128
+
+# Check containerd logs for inotify errors
+journalctl -u docker --since "5 minutes ago" | grep inotify
+# error from *cgroupsv2.Manager.EventChan: failed to create inotify fd: too many open files
+```
+
+## Fix
+
+Increase the inotify instance limit. A value of 1024 supports approximately 100 concurrent containers:
+
+```bash
+# Temporary (resets on reboot)
+sudo sysctl fs.inotify.max_user_instances=1024
+
+# Persistent
+echo "fs.inotify.max_user_instances = 1024" | sudo tee /etc/sysctl.d/99-sind.conf
+sudo sysctl --system
+```
+
+No restart of Docker or running containers is required. The new limit takes effect immediately for new containers.

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -12,6 +12,12 @@ import (
 	"github.com/GSI-HPC/sind/pkg/cmdexec"
 )
 
+// StreamResult holds the return values for a single Executor.Start call.
+type StreamResult struct {
+	Reader io.ReadCloser
+	Err    error
+}
+
 // Call records a single invocation of Executor.
 type Call struct {
 	Name  string
@@ -40,6 +46,10 @@ type Executor struct {
 	// The args slice contains the subcommand and its arguments
 	// (e.g. ["inspect", "sind-dns"]). Stdin is non-empty for RunWithStdin calls.
 	OnCall func(args []string, stdin string) Result
+
+	// OnStart, if set, is called to produce a StreamResult for Start calls.
+	// If nil, Start returns an error.
+	OnStart func(args []string) StreamResult
 
 	mu      sync.Mutex
 	Calls   []Call
@@ -87,4 +97,70 @@ func (m *Executor) RunWithStdin(_ context.Context, stdin io.Reader, name string,
 		return "", "", fmt.Errorf("mock: reading stdin: %w", err)
 	}
 	return m.record(name, args, string(data))
+}
+
+// Pipes manages io.Pipe pairs for mock streaming. Each OnStart call
+// creates a new pipe and returns its reader. Use Write to feed data into
+// a pipe by index, and CloseAll to shut them down.
+type Pipes struct {
+	mu    sync.Mutex
+	pipes []*io.PipeWriter
+}
+
+// OnStart is an OnStart callback that creates a new pipe per call.
+func (p *Pipes) OnStart(_ []string) StreamResult {
+	pr, pw := io.Pipe()
+	p.mu.Lock()
+	p.pipes = append(p.pipes, pw)
+	p.mu.Unlock()
+	return StreamResult{Reader: pr}
+}
+
+// Write sends data to the pipe at the given index.
+func (p *Pipes) Write(index int, data string) {
+	p.mu.Lock()
+	pw := p.pipes[index]
+	p.mu.Unlock()
+	_, _ = pw.Write([]byte(data))
+}
+
+// Len returns the number of pipes created so far.
+func (p *Pipes) Len() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.pipes)
+}
+
+// CloseWithError closes the pipe at the given index with an error,
+// causing the reader to return that error.
+func (p *Pipes) CloseWithError(index int, err error) {
+	p.mu.Lock()
+	pw := p.pipes[index]
+	p.mu.Unlock()
+	_ = pw.CloseWithError(err)
+}
+
+// CloseAll closes all pipe writers.
+func (p *Pipes) CloseAll() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, pw := range p.pipes {
+		_ = pw.Close()
+	}
+}
+
+// Start implements cmdexec.Executor.
+func (m *Executor) Start(_ context.Context, name string, args ...string) (*cmdexec.Process, error) {
+	m.mu.Lock()
+	m.Calls = append(m.Calls, Call{Name: name, Args: args})
+	m.mu.Unlock()
+
+	if m.OnStart != nil {
+		r := m.OnStart(args)
+		if r.Err != nil {
+			return nil, r.Err
+		}
+		return &cmdexec.Process{Stdout: r.Reader}, nil
+	}
+	return nil, fmt.Errorf("mock: unexpected Start call: %v", args)
 }

--- a/internal/mock/mock_test.go
+++ b/internal/mock/mock_test.go
@@ -145,3 +145,84 @@ func TestRecordingExecutor_RunWithStdin(t *testing.T) {
 	require.Len(t, calls, 1)
 	assert.Equal(t, "ok", calls[0].Stdout)
 }
+
+func TestExecutor_Start_OnStart(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+
+	m := Executor{
+		OnStart: func(args []string) StreamResult {
+			if args[0] == "events" {
+				return StreamResult{Reader: pr}
+			}
+			return StreamResult{Err: fmt.Errorf("unknown")}
+		},
+	}
+
+	proc, err := m.Start(t.Context(), "docker", "events")
+	require.NoError(t, err)
+	assert.NotNil(t, proc)
+	_ = proc.Close()
+
+	_, err = m.Start(t.Context(), "docker", "other")
+	require.Error(t, err)
+}
+
+func TestExecutor_Start_NoOnStart(t *testing.T) {
+	var m Executor
+	_, err := m.Start(t.Context(), "docker", "events")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected Start call")
+}
+
+func TestPipes(t *testing.T) {
+	var p Pipes
+	m := Executor{OnStart: p.OnStart}
+
+	proc, err := m.Start(t.Context(), "docker", "events")
+	require.NoError(t, err)
+
+	// io.Pipe is unbuffered — write must happen concurrently with read.
+	go p.Write(0, "hello\n")
+
+	buf := make([]byte, 6)
+	_, err = io.ReadFull(proc.Stdout, buf)
+	require.NoError(t, err)
+	assert.Equal(t, "hello\n", string(buf))
+
+	assert.Equal(t, 1, p.Len())
+
+	p.CloseAll()
+	_ = proc.Close()
+}
+
+func TestPipes_CloseWithError(t *testing.T) {
+	var p Pipes
+	m := Executor{OnStart: p.OnStart}
+
+	proc, err := m.Start(t.Context(), "docker", "events")
+	require.NoError(t, err)
+
+	p.CloseWithError(0, fmt.Errorf("connection reset"))
+
+	buf := make([]byte, 1)
+	_, err = proc.Stdout.Read(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection reset")
+	_ = proc.Close()
+}
+
+func TestRecordingExecutor_Start(t *testing.T) {
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+
+	rec := NewRecorder()
+	rec.mock.OnStart = func(_ []string) StreamResult {
+		return StreamResult{Reader: pr}
+	}
+
+	proc, err := rec.Start(t.Context(), "docker", "events")
+	require.NoError(t, err)
+	assert.NotNil(t, proc)
+	_ = proc.Close()
+}

--- a/internal/mock/recording.go
+++ b/internal/mock/recording.go
@@ -44,6 +44,13 @@ func (r *RecordingExecutor) RunWithStdin(ctx context.Context, stdin io.Reader, n
 	return stdout, stderr, err
 }
 
+// Start implements cmdexec.Executor.
+func (r *RecordingExecutor) Start(ctx context.Context, name string, args ...string) (*cmdexec.Process, error) {
+	proc, err := r.Inner.Start(ctx, name, args...)
+	r.record(RecordedCall{Name: name, Args: args, Err: err})
+	return proc, err
+}
+
 func (r *RecordingExecutor) record(call RecordedCall) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -212,27 +212,28 @@ func resolveInfra(ctx context.Context, client *docker.Client, meshMgr *mesh.Mana
 // createResources creates cluster network, volumes, config, and munge key.
 //
 //	┌─────────┐  ┌─────────┐
-//	│ network │  │ volumes │
-//	└────┬────┘  └────┬────┘
-//	     │       ┌────┴────┐
-//	     │  ┌────┴───┐ ┌───┴────┐
-//	     │  │ config │ │  munge │
-//	     │  └────┬───┘ └───┬────┘
-//	     └───────┼─────────┘
+//	network ║ (config vol → write config) ║ (munge vol → write munge key) ║ data vol
 func createResources(ctx context.Context, client *docker.Client, realm string, cfg *config.Cluster) error {
-	useDataVolume := cfg.Storage.DataStorage.HostPath == ""
-	g, gctx := errgroup.WithContext(ctx)
-	g.Go(func() error { return CreateClusterNetwork(gctx, client, realm, cfg.Name) })
-	g.Go(func() error { return CreateClusterVolumes(gctx, client, realm, cfg.Name, useDataVolume) })
-	if err := g.Wait(); err != nil {
-		return err
-	}
-
 	image := controllerImage(cfg)
 	mungeKey := slurm.GenerateMungeKey()
-	g, gctx = errgroup.WithContext(ctx)
-	g.Go(func() error { return WriteClusterConfig(gctx, client, realm, cfg, image, cfg.Pull) })
-	g.Go(func() error { return WriteMungeKey(gctx, client, realm, cfg.Name, mungeKey, image, cfg.Pull) })
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error { return CreateClusterNetwork(gctx, client, realm, cfg.Name) })
+	g.Go(func() error {
+		if err := CreateClusterVolume(gctx, client, realm, cfg.Name, VolumeConfig); err != nil {
+			return err
+		}
+		return WriteClusterConfig(gctx, client, realm, cfg, image, cfg.Pull)
+	})
+	g.Go(func() error {
+		if err := CreateClusterVolume(gctx, client, realm, cfg.Name, VolumeMunge); err != nil {
+			return err
+		}
+		return WriteMungeKey(gctx, client, realm, cfg.Name, mungeKey, image, cfg.Pull)
+	})
+	if cfg.Storage.DataStorage.HostPath == "" {
+		g.Go(func() error { return CreateClusterVolume(gctx, client, realm, cfg.Name, VolumeData) })
+	}
 	return g.Wait()
 }
 

--- a/pkg/cluster/create.go
+++ b/pkg/cluster/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/GSI-HPC/sind/pkg/docker"
 	sindlog "github.com/GSI-HPC/sind/pkg/log"
 	"github.com/GSI-HPC/sind/pkg/mesh"
+	"github.com/GSI-HPC/sind/pkg/monitor"
 	"github.com/GSI-HPC/sind/pkg/probe"
 	"github.com/GSI-HPC/sind/pkg/slurm"
 	"github.com/GSI-HPC/sind/pkg/ssh"
@@ -66,22 +67,18 @@ type nodeResult struct {
 //	      │
 //	resolveInfra        DNS IP ║ SSH key ║ Slurm version
 //	      │
-//	createResources     network ║ volumes → config ║ munge
+//	createResources     network ║ (config vol → write) ║ (munge vol → write)
 //	      │
-//	createAllNodes      node₁ ║ node₂ ║ ... ║ nodeₙ
+//	setupNodes          (create + wait + SSH + hostkey) per node
 //	      │
-//	setupNodes          (wait + SSH + hostkey) per node
-//	      │
-//	registerMesh        DNS records + known_hosts (serial)
-//	      │
-//	enableSlurm         (enable + probe) per eligible node
+//	registerMesh ║ enableSlurm
 //	      │
 //	  *Cluster
 func Create(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager, cfg *config.Cluster, readinessInterval time.Duration) (result *Cluster, retErr error) {
 	log := sindlog.From(ctx)
 	realm := meshMgr.Realm
 
-	log.InfoContext(ctx, "creating cluster", "name", cfg.Name, "nodes", len(cfg.Nodes))
+	log.InfoContext(ctx, "creating cluster", "name", cfg.Name, "nodes", len(NodeShortNames(cfg.Nodes)))
 
 	// Register cleanup before any fallible operation. Mesh cleanup runs
 	// whenever this invocation created the mesh. Cluster resource cleanup
@@ -133,27 +130,44 @@ func Create(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager, c
 
 	nodeConfigs := NodeRunConfigs(cfg, realm, dnsIP, slurmVersion)
 	logExtraPrivileges(ctx, nodeConfigs)
-	if err := createAllNodes(ctx, client, meshMgr, nodeConfigs); err != nil {
-		return nil, err
-	}
-	log.InfoContext(ctx, "node containers started", "count", len(nodeConfigs))
 
-	nodeResults, err := setupNodes(ctx, client, realm, cfg.Name, sshPubKey, nodeConfigs, readinessInterval)
+	// Start event watcher before creating nodes so it captures all
+	// container start events. If the watcher fails to start, fall back
+	// to poll-only mode.
+	prefix := ContainerPrefix(realm, cfg.Name)
+	watcher, stopWatcher := startWatcher(ctx, client, prefix, cfg.Name)
+	defer stopWatcher()
+
+	nodeResults, err := setupNodes(ctx, client, meshMgr, realm, cfg.Name, sshPubKey, nodeConfigs, readinessInterval, watcher)
 	if err != nil {
 		return nil, err
 	}
 	log.InfoContext(ctx, "nodes ready", "count", len(nodeConfigs))
 
-	cluster, err := registerMesh(ctx, meshMgr, cfg.Name, slurmVersion, nodeConfigs, nodeResults)
-	if err != nil {
+	// registerMesh and enableSlurm are independent: Slurm uses short
+	// hostnames resolved by Docker embedded DNS on the cluster network.
+	// Mesh DNS records are for SSH relay and host-side resolution only.
+	var cluster *Cluster
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		var meshErr error
+		cluster, meshErr = registerMesh(gctx, meshMgr, cfg.Name, slurmVersion, nodeConfigs, nodeResults)
+		if meshErr != nil {
+			return meshErr
+		}
+		log.DebugContext(gctx, "mesh registration complete")
+		return nil
+	})
+	g.Go(func() error {
+		if err := enableSlurm(gctx, client, realm, cfg.Name, nodeConfigs, readinessInterval, watcher); err != nil {
+			return err
+		}
+		log.InfoContext(gctx, "slurm services enabled")
+		return nil
+	})
+	if err := g.Wait(); err != nil {
 		return nil, err
 	}
-	log.DebugContext(ctx, "mesh registration complete")
-
-	if err := enableSlurm(ctx, client, realm, cfg.Name, nodeConfigs, readinessInterval); err != nil {
-		return nil, err
-	}
-	log.InfoContext(ctx, "slurm services enabled")
 
 	return cluster, nil
 }
@@ -237,36 +251,12 @@ func createResources(ctx context.Context, client *docker.Client, realm string, c
 	return g.Wait()
 }
 
-// createAllNodes creates and starts all node containers concurrently.
+// setupNodes creates each node, starts its systemd monitor, waits for base
+// readiness, injects SSH public keys, and collects host keys — all
+// concurrently per node with no barrier between creation and probing.
 //
-//	┌───────┐ ┌───────┐     ┌───────┐
-//	│ node₁ │ │ node₂ │ ... │ nodeₙ │
-//	└───┬───┘ └───┬───┘     └───┬───┘
-//	    └─────────┼─────────────┘
-func createAllNodes(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager, nodeConfigs []RunConfig) error {
-	g, gctx := errgroup.WithContext(ctx)
-	for _, nc := range nodeConfigs {
-		g.Go(func() error {
-			_, err := CreateNode(gctx, client, meshMgr, nc)
-			if err != nil {
-				return fmt.Errorf("node %s: %w", nc.ShortName, err)
-			}
-			return nil
-		})
-	}
-	return g.Wait()
-}
-
-// setupNodes waits for base readiness, injects SSH public keys, and collects
-// host keys from each node — all concurrently.
-//
-//	per node:  wait(container, systemd, sshd) → inspect → SSH inject → host key
-//
-//	┌───────────────┐ ┌───────────────┐     ┌───────────────┐
-//	│ node₁ setup   │ │ node₂ setup   │ ... │ nodeₙ setup   │
-//	└───────┬───────┘ └───────┬───────┘     └───────┬───────┘
-//	        └─────────────────┼─────────────────────┘
-func setupNodes(ctx context.Context, client *docker.Client, realm, clusterName, sshPubKey string, nodeConfigs []RunConfig, interval time.Duration) ([]nodeResult, error) {
+//	per node:  create → monitor → wait(container, systemd, sshd) → inspect → SSH → hostkey
+func setupNodes(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager, realm, clusterName, sshPubKey string, nodeConfigs []RunConfig, interval time.Duration, watcher *monitor.Watcher) ([]nodeResult, error) {
 	log := sindlog.From(ctx)
 	baseProbes := []probe.Probe{
 		{Name: "container", Check: probe.ContainerRunning},
@@ -280,8 +270,19 @@ func setupNodes(ctx context.Context, client *docker.Client, realm, clusterName, 
 		g.Go(func() error {
 			containerName := ContainerName(realm, clusterName, nc.ShortName)
 
+			if _, err := CreateNode(gctx, client, meshMgr, nc); err != nil {
+				return fmt.Errorf("node %s: %w", nc.ShortName, err)
+			}
+
+			if watcher != nil {
+				watcher.AddNodes(gctx, []monitor.NodeTarget{{
+					ShortName: nc.ShortName,
+					Container: containerName,
+				}})
+			}
+
 			log.DebugContext(gctx, "waiting for node", "node", nc.ShortName)
-			if err := probe.UntilReady(gctx, client, containerName, baseProbes, interval); err != nil {
+			if err := waitReady(gctx, client, containerName, baseProbes, interval, watcher); err != nil {
 				return fmt.Errorf("waiting for %s: %w", nc.ShortName, err)
 			}
 
@@ -306,9 +307,8 @@ func setupNodes(ctx context.Context, client *docker.Client, realm, clusterName, 
 	return results, g.Wait()
 }
 
-// registerMesh writes DNS records and known hosts for all nodes, and builds
-// the Cluster result. Serial because AddDNSRecord is a read-modify-write
-// on the shared Corefile.
+// registerMesh writes DNS records and known hosts for all nodes in batch,
+// and builds the Cluster result.
 func registerMesh(ctx context.Context, meshMgr *mesh.Manager, clusterName, slurmVersion string, nodeConfigs []RunConfig, results []nodeResult) (*Cluster, error) {
 	nodes, err := registerNodes(ctx, meshMgr, clusterName, nodeConfigs, results)
 	if err != nil {
@@ -322,31 +322,36 @@ func registerMesh(ctx context.Context, meshMgr *mesh.Manager, clusterName, slurm
 	}, nil
 }
 
-// registerNodes registers DNS records and known_hosts entries for each node,
-// and returns the resulting Node list. Serial because AddDNSRecord is a
-// read-modify-write on the shared Corefile.
+// registerNodes registers DNS records and known_hosts entries for all nodes
+// in batch, and returns the resulting Node list.
 func registerNodes(ctx context.Context, meshMgr *mesh.Manager, clusterName string, nodeConfigs []RunConfig, results []nodeResult) ([]*Node, error) {
-	nodes := make([]*Node, 0, len(nodeConfigs))
+	dnsRecords := make([]mesh.DNSRecord, len(nodeConfigs))
+	hostEntries := make([]mesh.KnownHostEntry, len(nodeConfigs))
+	nodes := make([]*Node, len(nodeConfigs))
+
 	for i, nc := range nodeConfigs {
 		nr := results[i]
-		nodeIP := nr.info.IPs[NetworkName(meshMgr.Realm, clusterName)]
+		netName := NetworkName(meshMgr.Realm, clusterName)
 		dnsName := DNSName(nc.ShortName, clusterName, meshMgr.Realm)
 
-		if err := meshMgr.AddDNSRecord(ctx, dnsName, nodeIP); err != nil {
-			return nil, fmt.Errorf("registering DNS for %s: %w", nc.ShortName, err)
-		}
-		if err := meshMgr.AddKnownHost(ctx, dnsName, nr.hostKey); err != nil {
-			return nil, fmt.Errorf("registering host key for %s: %w", nc.ShortName, err)
-		}
-
-		nodes = append(nodes, &Node{
+		dnsRecords[i] = mesh.DNSRecord{Hostname: dnsName, IP: nr.info.IPs[netName]}
+		hostEntries[i] = mesh.KnownHostEntry{Hostname: dnsName, HostKey: nr.hostKey}
+		nodes[i] = &Node{
 			Name:        nc.ShortName,
 			Role:        nc.Role,
 			ContainerID: nr.info.ID,
-			IP:          nr.info.IPs[NetworkName(meshMgr.Realm, clusterName)],
+			IP:          nr.info.IPs[netName],
 			State:       StateRunning,
-		})
+		}
 	}
+
+	if err := meshMgr.AddDNSRecords(ctx, dnsRecords); err != nil {
+		return nil, fmt.Errorf("registering DNS: %w", err)
+	}
+	if err := meshMgr.AddKnownHosts(ctx, hostEntries); err != nil {
+		return nil, fmt.Errorf("registering host keys: %w", err)
+	}
+
 	return nodes, nil
 }
 
@@ -359,7 +364,7 @@ func registerNodes(ctx context.Context, meshMgr *mesh.Manager, clusterName strin
 //	│ wait slurmctld     │ │ wait slurmd          │
 //	└─────────┬──────────┘ └──────────┬───────────┘
 //	          └───────────┬───────────┘
-func enableSlurm(ctx context.Context, client *docker.Client, realm, clusterName string, nodeConfigs []RunConfig, interval time.Duration) error {
+func enableSlurm(ctx context.Context, client *docker.Client, realm, clusterName string, nodeConfigs []RunConfig, interval time.Duration, watcher *monitor.Watcher) error {
 	log := sindlog.From(ctx)
 	g, gctx := errgroup.WithContext(ctx)
 	for _, nc := range nodeConfigs {
@@ -378,8 +383,37 @@ func enableSlurm(ctx context.Context, client *docker.Client, realm, clusterName 
 			if err != nil {
 				return fmt.Errorf("enabling %s on %s: %w", service, nc.ShortName, err)
 			}
-			return probe.UntilReady(gctx, client, containerName, []probe.Probe{slurmProbe}, interval)
+			return waitReady(gctx, client, containerName, []probe.Probe{slurmProbe}, interval, watcher)
 		})
 	}
 	return g.Wait()
+}
+
+// startWatcher creates and starts an event watcher for the given cluster.
+// If the watcher fails to start (e.g. docker events unavailable), nil is
+// returned and the caller falls back to poll-only mode. The returned stop
+// function cancels the watcher and waits for its goroutines to exit.
+func startWatcher(ctx context.Context, client *docker.Client, containerPrefix, clusterName string) (w *monitor.Watcher, stop func()) {
+	watchCtx, cancel := context.WithCancel(ctx)
+	w = monitor.NewWatcher(client.Executor, containerPrefix, clusterName)
+	if err := w.Start(watchCtx, nil); err != nil {
+		cancel()
+		sindlog.From(ctx).Log(ctx, sindlog.LevelTrace, "event watcher not available, using poll-only mode", "err", err)
+		return nil, func() {}
+	}
+	return w, func() {
+		cancel()
+		w.Wait()
+	}
+}
+
+// waitReady polls probes until ready, optionally accelerated by events from
+// a watcher. If watcher is nil, falls back to plain polling.
+func waitReady(ctx context.Context, client *docker.Client, name docker.ContainerName, probes []probe.Probe, interval time.Duration, watcher *monitor.Watcher) error {
+	if watcher == nil {
+		return probe.UntilReady(ctx, client, name, probes, interval)
+	}
+	ch := watcher.Subscribe()
+	defer watcher.Unsubscribe(ch)
+	return probe.UntilReadyWithEvents(ctx, client, name, probes, interval, ch)
 }

--- a/pkg/cluster/create_test.go
+++ b/pkg/cluster/create_test.go
@@ -5,6 +5,7 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -16,6 +17,8 @@ import (
 	"github.com/GSI-HPC/sind/pkg/config"
 	"github.com/GSI-HPC/sind/pkg/docker"
 	"github.com/GSI-HPC/sind/pkg/mesh"
+	"github.com/GSI-HPC/sind/pkg/monitor"
+	"github.com/GSI-HPC/sind/pkg/probe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -212,7 +215,7 @@ func happyOnCall(t *testing.T, exitErr *exec.ExitError, override func(args []str
 		if args[0] == "kill" {
 			return mock.Result{}
 		}
-		t.Errorf("unexpected docker call: %v", args)
+		assert.Failf(t, "unexpected docker call", "%v", args)
 		return mock.Result{Err: fmt.Errorf("unexpected call: %v", args)}
 	}
 }
@@ -231,8 +234,12 @@ func createCfg() *config.Cluster {
 func TestCreate_FullCluster(t *testing.T) {
 	exitErr := notFoundErr(t)
 
+	pipes := &mock.Pipes{}
+	defer pipes.CloseAll()
+
 	var m mock.Executor
 	m.OnCall = happyOnCall(t, exitErr, nil)
+	m.OnStart = pipes.OnStart
 
 	client := docker.NewClient(&m)
 	meshMgr := mesh.NewManager(client, mesh.DefaultRealm)
@@ -310,6 +317,26 @@ func TestCreate_CreateResourcesFails(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "creating cluster network")
+	assert.Nil(t, cluster)
+}
+
+func TestCreate_VolumeCreateFails(t *testing.T) {
+	exitErr := notFoundErr(t)
+	var m mock.Executor
+	m.OnCall = happyOnCall(t, exitErr, func(args []string, _ string) (mock.Result, bool) {
+		if args[0] == "volume" && args[1] == "create" {
+			return mock.Result{Err: fmt.Errorf("volume quota exceeded")}, true
+		}
+		return mock.Result{}, false
+	})
+
+	client := docker.NewClient(&m)
+	meshMgr := mesh.NewManager(client, mesh.DefaultRealm)
+
+	cluster, err := Create(t.Context(), client, meshMgr, createCfg(), time.Millisecond)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "volume")
 	assert.Nil(t, cluster)
 }
 
@@ -529,7 +556,7 @@ func TestCreate_SkipsMeshCleanupWhenPreExisting(t *testing.T) {
 			continue
 		}
 		if seenPs && len(call.Args) >= 2 && call.Args[0] == "container" && call.Args[1] == "inspect" {
-			t.Fatal("mesh cleanup should not run when mesh was pre-existing")
+			require.Fail(t, "mesh cleanup should not run when mesh was pre-existing")
 		}
 	}
 }
@@ -551,7 +578,7 @@ func TestCreate_NoCleanupOnPreflightFailure(t *testing.T) {
 	// No "docker ps" calls → cleanup did not run.
 	for _, call := range m.Calls {
 		if len(call.Args) > 0 && call.Args[0] == "ps" {
-			t.Fatal("cleanup should not run when preflight fails")
+			require.Fail(t, "cleanup should not run when preflight fails")
 		}
 	}
 }
@@ -576,7 +603,7 @@ func TestCreate_NoClusterCleanupOnResolveInfraFailure(t *testing.T) {
 	require.Error(t, err)
 	for _, call := range m.Calls {
 		if len(call.Args) > 0 && call.Args[0] == "ps" {
-			t.Fatal("cluster cleanup should not run when resolveInfra fails")
+			require.Fail(t, "cluster cleanup should not run when resolveInfra fails")
 		}
 	}
 }
@@ -832,7 +859,8 @@ func TestSetupNodes_InspectError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
-	_, err := setupNodes(ctx, client, mesh.DefaultRealm, "dev", "ssh-key", configs, time.Millisecond)
+	mgr := mesh.NewManager(client, mesh.DefaultRealm)
+	_, err := setupNodes(ctx, client, mgr, mesh.DefaultRealm, "dev", "ssh-key", configs, time.Millisecond, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "inspecting node controller")
@@ -865,7 +893,8 @@ func TestSetupNodes_InjectKeyError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
-	_, err := setupNodes(ctx, client, mesh.DefaultRealm, "dev", "ssh-key", configs, time.Millisecond)
+	mgr := mesh.NewManager(client, mesh.DefaultRealm)
+	_, err := setupNodes(ctx, client, mgr, mesh.DefaultRealm, "dev", "ssh-key", configs, time.Millisecond, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "injecting SSH key")
@@ -903,7 +932,8 @@ func TestSetupNodes_HostKeyError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
-	_, err := setupNodes(ctx, client, mesh.DefaultRealm, "dev", "ssh-key", configs, time.Millisecond)
+	mgr := mesh.NewManager(client, mesh.DefaultRealm)
+	_, err := setupNodes(ctx, client, mgr, mesh.DefaultRealm, "dev", "ssh-key", configs, time.Millisecond, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "collecting host key")
@@ -1035,8 +1065,74 @@ func TestEnableSlurm_ProbeTimeout(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
-	err := enableSlurm(ctx, client, mesh.DefaultRealm, "dev", configs, 10*time.Millisecond)
+	err := enableSlurm(ctx, client, mesh.DefaultRealm, "dev", configs, 10*time.Millisecond, nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not ready")
+}
+
+func TestStartWatcher_Success(t *testing.T) {
+	pipes := &mock.Pipes{}
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	client := docker.NewClient(m)
+
+	w, stop := startWatcher(t.Context(), client, "sind-dev-", "dev")
+	assert.NotNil(t, w)
+	// Close pipe writers to unblock scanner reads before stopping.
+	pipes.CloseAll()
+	stop()
+}
+
+func TestStartWatcher_Fallback(t *testing.T) {
+	// When docker events fails to start, startWatcher returns nil
+	// and callers fall back to poll-only mode.
+	m := &mock.Executor{
+		OnStart: func(_ []string) mock.StreamResult {
+			return mock.StreamResult{Err: errors.New("docker not available")}
+		},
+	}
+	client := docker.NewClient(m)
+
+	w, stop := startWatcher(t.Context(), client, "sind-dev-", "dev")
+	defer stop()
+	assert.Nil(t, w)
+}
+
+func TestWaitReady_NilWatcher(t *testing.T) {
+	// waitReady with nil watcher should fall back to UntilReady.
+	containerName := ContainerName(mesh.DefaultRealm, "dev", "controller")
+	var m mock.Executor
+	m.AddResult(inspectJSON(t, string(containerName), "running", nil), "", nil)
+	client := docker.NewClient(&m)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	probes := []probe.Probe{{Name: "container", Check: probe.ContainerRunning}}
+	err := waitReady(ctx, client, containerName, probes, time.Millisecond, nil)
+	require.NoError(t, err)
+}
+
+func TestWaitReady_WithWatcher(t *testing.T) {
+	// waitReady with a watcher should use UntilReadyWithEvents.
+	containerName := ContainerName(mesh.DefaultRealm, "dev", "controller")
+
+	pipes := &mock.Pipes{}
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	m.AddResult(inspectJSON(t, string(containerName), "running", nil), "", nil)
+	client := docker.NewClient(m)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	w := monitor.NewWatcher(m, "sind-dev-", "dev")
+	require.NoError(t, w.Start(ctx, nil))
+
+	probes := []probe.Probe{{Name: "container", Check: probe.ContainerRunning}}
+	err := waitReady(ctx, client, containerName, probes, time.Millisecond, w)
+	require.NoError(t, err)
+
+	cancel()
+	pipes.CloseAll()
+	w.Wait()
 }

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GSI-HPC/sind/pkg/docker"
 	sindlog "github.com/GSI-HPC/sind/pkg/log"
 	"github.com/GSI-HPC/sind/pkg/mesh"
+	"golang.org/x/sync/errgroup"
 )
 
 // Delete orchestrates the full cluster deletion flow.
@@ -102,14 +103,18 @@ func deleteClusterResources(ctx context.Context, client *docker.Client, meshMgr 
 	return nil
 }
 
-// DeleteContainers force-removes the given containers (docker rm -f).
+// DeleteContainers force-removes the given containers in parallel (docker rm -f).
 func DeleteContainers(ctx context.Context, client *docker.Client, containers []docker.ContainerListEntry) error {
+	g, gctx := errgroup.WithContext(ctx)
 	for _, c := range containers {
-		if err := client.RemoveContainer(ctx, c.Name); err != nil {
-			return fmt.Errorf("removing container %s: %w", c.Name, err)
-		}
+		g.Go(func() error {
+			if err := client.RemoveContainer(gctx, c.Name); err != nil {
+				return fmt.Errorf("removing container %s: %w", c.Name, err)
+			}
+			return nil
+		})
 	}
-	return nil
+	return g.Wait()
 }
 
 // DeleteNetwork removes the cluster network.
@@ -130,20 +135,25 @@ func DeleteVolumes(ctx context.Context, client *docker.Client, volumes []docker.
 	return nil
 }
 
-// DeregisterMesh removes DNS records and known_hosts entries for each container
-// in the cluster. This is the inverse of registerMesh during cluster creation.
+// DeregisterMesh removes DNS records and known_hosts entries for all
+// containers in batch. This is the inverse of registerMesh during cluster
+// creation.
 func DeregisterMesh(ctx context.Context, meshMgr *mesh.Manager, clusterName string, containers []docker.ContainerListEntry) error {
+	if len(containers) == 0 {
+		return nil
+	}
 	prefix := ContainerPrefix(meshMgr.Realm, clusterName)
-	for _, c := range containers {
+	hostnames := make([]string, len(containers))
+	for i, c := range containers {
 		shortName := strings.TrimPrefix(string(c.Name), prefix)
-		dnsName := DNSName(shortName, clusterName, meshMgr.Realm)
+		hostnames[i] = DNSName(shortName, clusterName, meshMgr.Realm)
+	}
 
-		if err := meshMgr.RemoveDNSRecord(ctx, dnsName); err != nil {
-			return fmt.Errorf("removing DNS record for %s: %w", shortName, err)
-		}
-		if err := meshMgr.RemoveKnownHost(ctx, dnsName); err != nil {
-			return fmt.Errorf("removing known host for %s: %w", shortName, err)
-		}
+	if err := meshMgr.RemoveDNSRecords(ctx, hostnames); err != nil {
+		return fmt.Errorf("removing DNS records: %w", err)
+	}
+	if err := meshMgr.RemoveKnownHosts(ctx, hostnames); err != nil {
+		return fmt.Errorf("removing known hosts: %w", err)
 	}
 	return nil
 }

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -20,8 +20,7 @@ import (
 
 func TestDeleteContainers(t *testing.T) {
 	var m mock.Executor
-	m.AddResult("", "", nil) // rm -f container 1
-	m.AddResult("", "", nil) // rm -f container 2
+	m.OnCall = func(_ []string, _ string) mock.Result { return mock.Result{} }
 	c := docker.NewClient(&m)
 
 	containers := []docker.ContainerListEntry{
@@ -32,8 +31,9 @@ func TestDeleteContainers(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, m.Calls, 2)
-	assert.Equal(t, []string{"rm", "-f", "sind-dev-controller"}, m.Calls[0].Args)
-	assert.Equal(t, []string{"rm", "-f", "sind-dev-worker-0"}, m.Calls[1].Args)
+	// Order is nondeterministic (parallel removal).
+	names := []string{m.Calls[0].Args[2], m.Calls[1].Args[2]}
+	assert.ElementsMatch(t, []string{"sind-dev-controller", "sind-dev-worker-0"}, names)
 }
 
 func TestDeleteContainers_RemoveError(t *testing.T) {
@@ -175,7 +175,7 @@ func TestDeregisterMesh_DNSError(t *testing.T) {
 	err := DeregisterMesh(t.Context(), mgr, "dev", containers)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "removing DNS record for controller")
+	assert.Contains(t, err.Error(), "removing DNS records")
 }
 
 func TestDeregisterMesh_KnownHostError(t *testing.T) {
@@ -208,7 +208,7 @@ func TestDeregisterMesh_KnownHostError(t *testing.T) {
 	err := DeregisterMesh(t.Context(), mgr, "dev", containers)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "removing known host for controller")
+	assert.Contains(t, err.Error(), "removing known hosts")
 }
 
 // --- Delete Orchestrator ---

--- a/pkg/cluster/preflight.go
+++ b/pkg/cluster/preflight.go
@@ -5,10 +5,13 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/GSI-HPC/sind/pkg/config"
 	"github.com/GSI-HPC/sind/pkg/docker"
+	"golang.org/x/sync/errgroup"
 )
 
 // NodeShortNames returns the short hostname for each node defined in the config.
@@ -39,43 +42,60 @@ func NodeShortNames(nodes []config.Node) []string {
 // that would be created from the given configuration. It checks for existing
 // networks, volumes, and containers with matching names.
 func PreflightCheck(ctx context.Context, client *docker.Client, realm string, cfg *config.Cluster) error {
-	var conflicts []string
+	var (
+		mu        sync.Mutex
+		conflicts []string
+	)
+
+	check := func(ctx context.Context, kind, name string, existsFn func(context.Context) (bool, error)) error {
+		exists, err := existsFn(ctx)
+		if err != nil {
+			return fmt.Errorf("checking %s %s: %w", kind, name, err)
+		}
+		if exists {
+			mu.Lock()
+			conflicts = append(conflicts, kind+" "+name)
+			mu.Unlock()
+		}
+		return nil
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
 
 	// Check cluster network.
 	netName := NetworkName(realm, cfg.Name)
-	exists, err := client.NetworkExists(ctx, netName)
-	if err != nil {
-		return fmt.Errorf("checking network %s: %w", netName, err)
-	}
-	if exists {
-		conflicts = append(conflicts, "network "+string(netName))
-	}
+	g.Go(func() error {
+		return check(gctx, "network", string(netName), func(ctx context.Context) (bool, error) {
+			return client.NetworkExists(ctx, netName)
+		})
+	})
 
 	// Check cluster volumes.
 	for _, vtype := range AllVolumeTypes {
 		volName := VolumeName(realm, cfg.Name, vtype)
-		exists, err := client.VolumeExists(ctx, volName)
-		if err != nil {
-			return fmt.Errorf("checking volume %s: %w", volName, err)
-		}
-		if exists {
-			conflicts = append(conflicts, "volume "+string(volName))
-		}
+		g.Go(func() error {
+			return check(gctx, "volume", string(volName), func(ctx context.Context) (bool, error) {
+				return client.VolumeExists(ctx, volName)
+			})
+		})
 	}
 
 	// Check node containers.
 	for _, shortName := range NodeShortNames(cfg.Nodes) {
 		containerName := ContainerName(realm, cfg.Name, shortName)
-		exists, err := client.ContainerExists(ctx, containerName)
-		if err != nil {
-			return fmt.Errorf("checking container %s: %w", containerName, err)
-		}
-		if exists {
-			conflicts = append(conflicts, "container "+string(containerName))
-		}
+		g.Go(func() error {
+			return check(gctx, "container", string(containerName), func(ctx context.Context) (bool, error) {
+				return client.ContainerExists(ctx, containerName)
+			})
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
 	}
 
 	if len(conflicts) > 0 {
+		sort.Strings(conflicts)
 		return fmt.Errorf("conflicting resources already exist: %s", strings.Join(conflicts, ", "))
 	}
 

--- a/pkg/cluster/preflight_test.go
+++ b/pkg/cluster/preflight_test.go
@@ -83,21 +83,36 @@ func TestNodeShortNames(t *testing.T) {
 
 // --- PreflightCheck ---
 
+// preflightOnCall returns an OnCall handler where resources in the exists
+// set return success (resource found) and all others return not-found.
+func preflightOnCall(t *testing.T, exists map[string]bool) func([]string, string) mock.Result {
+	t.Helper()
+	notFound := testutil.ExitCode1(t)
+	return func(args []string, _ string) mock.Result {
+		// docker <type> inspect <name>
+		name := args[len(args)-1]
+		if exists[name] {
+			return mock.Result{}
+		}
+		return mock.Result{Stderr: "Error: No such object\n", Err: notFound}
+	}
+}
+
 func TestPreflightCheck_NoConflicts(t *testing.T) {
-	m := preflightMock(t, 6, false) // network + 3 volumes + 2 containers
-	c := docker.NewClient(m)
+	var m mock.Executor
+	m.OnCall = preflightOnCall(t, nil)
+	c := docker.NewClient(&m)
 
 	cfg := minimalConfig()
 	err := PreflightCheck(t.Context(), c, mesh.DefaultRealm, cfg)
 
 	require.NoError(t, err)
-	assert.Len(t, m.Calls, 6)
+	assert.Len(t, m.Calls, 6) // network + 3 volumes + 2 containers
 }
 
 func TestPreflightCheck_ConflictingNetwork(t *testing.T) {
 	var m mock.Executor
-	m.AddResult("", "", nil) // network exists
-	addNotFound(t, &m, 5)    // volumes + containers
+	m.OnCall = preflightOnCall(t, map[string]bool{"sind-dev-net": true})
 	c := docker.NewClient(&m)
 
 	cfg := minimalConfig()
@@ -109,11 +124,10 @@ func TestPreflightCheck_ConflictingNetwork(t *testing.T) {
 
 func TestPreflightCheck_ConflictingVolumes(t *testing.T) {
 	var m mock.Executor
-	addNotFound(t, &m, 1)    // network
-	m.AddResult("", "", nil) // config volume exists
-	addNotFound(t, &m, 1)    // munge volume
-	m.AddResult("", "", nil) // data volume exists
-	addNotFound(t, &m, 2)    // containers
+	m.OnCall = preflightOnCall(t, map[string]bool{
+		"sind-dev-config": true,
+		"sind-dev-data":   true,
+	})
 	c := docker.NewClient(&m)
 
 	cfg := minimalConfig()
@@ -127,9 +141,7 @@ func TestPreflightCheck_ConflictingVolumes(t *testing.T) {
 
 func TestPreflightCheck_ConflictingContainers(t *testing.T) {
 	var m mock.Executor
-	addNotFound(t, &m, 4)    // network + 3 volumes
-	m.AddResult("", "", nil) // controller exists
-	addNotFound(t, &m, 1)    // worker-0
+	m.OnCall = preflightOnCall(t, map[string]bool{"sind-dev-controller": true})
 	c := docker.NewClient(&m)
 
 	cfg := minimalConfig()
@@ -142,10 +154,11 @@ func TestPreflightCheck_ConflictingContainers(t *testing.T) {
 
 func TestPreflightCheck_MultipleConflicts(t *testing.T) {
 	var m mock.Executor
-	m.AddResult("", "", nil) // network exists
-	addNotFound(t, &m, 3)    // volumes
-	m.AddResult("", "", nil) // controller exists
-	m.AddResult("", "", nil) // worker-0 exists
+	m.OnCall = preflightOnCall(t, map[string]bool{
+		"sind-dev-net":        true,
+		"sind-dev-controller": true,
+		"sind-dev-worker-0":   true,
+	})
 	c := docker.NewClient(&m)
 
 	cfg := minimalConfig()
@@ -159,7 +172,13 @@ func TestPreflightCheck_MultipleConflicts(t *testing.T) {
 
 func TestPreflightCheck_NetworkCheckError(t *testing.T) {
 	var m mock.Executor
-	m.AddResult("", "", fmt.Errorf("docker daemon not running"))
+	m.OnCall = func(args []string, _ string) mock.Result {
+		name := args[len(args)-1]
+		if name == "sind-dev-net" {
+			return mock.Result{Err: fmt.Errorf("docker daemon not running")}
+		}
+		return mock.Result{Stderr: "Error: No such object\n", Err: testutil.ExitCode1(t)}
+	}
 	c := docker.NewClient(&m)
 
 	cfg := minimalConfig()
@@ -171,8 +190,13 @@ func TestPreflightCheck_NetworkCheckError(t *testing.T) {
 
 func TestPreflightCheck_VolumeCheckError(t *testing.T) {
 	var m mock.Executor
-	addNotFound(t, &m, 1) // network
-	m.AddResult("", "", fmt.Errorf("permission denied"))
+	m.OnCall = func(args []string, _ string) mock.Result {
+		name := args[len(args)-1]
+		if name == "sind-dev-config" {
+			return mock.Result{Err: fmt.Errorf("permission denied")}
+		}
+		return mock.Result{Stderr: "Error: No such object\n", Err: testutil.ExitCode1(t)}
+	}
 	c := docker.NewClient(&m)
 
 	cfg := minimalConfig()
@@ -184,8 +208,13 @@ func TestPreflightCheck_VolumeCheckError(t *testing.T) {
 
 func TestPreflightCheck_ContainerCheckError(t *testing.T) {
 	var m mock.Executor
-	addNotFound(t, &m, 4) // network + volumes
-	m.AddResult("", "", fmt.Errorf("connection refused"))
+	m.OnCall = func(args []string, _ string) mock.Result {
+		name := args[len(args)-1]
+		if name == "sind-dev-controller" {
+			return mock.Result{Err: fmt.Errorf("connection refused")}
+		}
+		return mock.Result{Stderr: "Error: No such object\n", Err: testutil.ExitCode1(t)}
+	}
 	c := docker.NewClient(&m)
 
 	cfg := minimalConfig()
@@ -196,13 +225,11 @@ func TestPreflightCheck_ContainerCheckError(t *testing.T) {
 }
 
 func TestPreflightCheck_MultiCompute(t *testing.T) {
-	// 1 controller + 3 worker = 4 containers + 1 network + 3 volumes = 8 checks
 	var m mock.Executor
-	addNotFound(t, &m, 4)    // network + volumes
-	addNotFound(t, &m, 1)    // controller
-	m.AddResult("", "", nil) // worker-0 exists
-	addNotFound(t, &m, 1)    // worker-1
-	m.AddResult("", "", nil) // worker-2 exists
+	m.OnCall = preflightOnCall(t, map[string]bool{
+		"sind-dev-worker-0": true,
+		"sind-dev-worker-2": true,
+	})
 	c := docker.NewClient(&m)
 
 	cfg := &config.Cluster{
@@ -222,31 +249,6 @@ func TestPreflightCheck_MultiCompute(t *testing.T) {
 
 // --- helpers ---
 
-func minimalConfig() *config.Cluster {
-	return &config.Cluster{
-		Name: "dev",
-		Nodes: []config.Node{
-			{Role: config.RoleController},
-			{Role: config.RoleWorker, Count: 1},
-		},
-	}
-}
-
-// preflightMock returns a MockExecutor with n "not found" results (exit code 1).
-// If existAll is true, all results return success instead.
-func preflightMock(t *testing.T, n int, existAll bool) *mock.Executor {
-	t.Helper()
-	var m mock.Executor
-	for i := 0; i < n; i++ {
-		if existAll {
-			m.AddResult("", "", nil)
-		} else {
-			addNotFound(t, &m, 1)
-		}
-	}
-	return &m
-}
-
 // addNotFound adds n "not found" results (exit code 1) to the mock.
 func addNotFound(t *testing.T, m *mock.Executor, n int) {
 	t.Helper()
@@ -256,4 +258,12 @@ func addNotFound(t *testing.T, m *mock.Executor, n int) {
 	}
 }
 
-// exitCode1 runs a command that exits with code 1 and returns its ProcessState.
+func minimalConfig() *config.Cluster {
+	return &config.Cluster{
+		Name: "dev",
+		Nodes: []config.Node{
+			{Role: config.RoleController},
+			{Role: config.RoleWorker, Count: 1},
+		},
+	}
+}

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -24,22 +24,14 @@ func CreateClusterNetwork(ctx context.Context, client *docker.Client, realm, clu
 	return nil
 }
 
-// CreateClusterVolumes creates the config and munge volumes for a cluster.
-// When useDataVolume is true, a data volume is also created; otherwise the
-// caller is expected to use a host-path bind mount for /data.
-func CreateClusterVolumes(ctx context.Context, client *docker.Client, realm, clusterName string, useDataVolume bool) error {
-	types := []VolumeType{VolumeConfig, VolumeMunge}
-	if useDataVolume {
-		types = append(types, VolumeData)
+// CreateClusterVolume creates a single cluster volume.
+func CreateClusterVolume(ctx context.Context, client *docker.Client, realm, clusterName string, vtype VolumeType) error {
+	labels := docker.Labels{
+		docker.ComposeProjectLabel: ComposeProject(realm, clusterName),
+		docker.ComposeVolumeLabel:  string(vtype),
 	}
-	for _, vtype := range types {
-		labels := docker.Labels{
-			docker.ComposeProjectLabel: ComposeProject(realm, clusterName),
-			docker.ComposeVolumeLabel:  string(vtype),
-		}
-		if err := client.CreateVolume(ctx, VolumeName(realm, clusterName, vtype), labels); err != nil {
-			return fmt.Errorf("creating %s volume: %w", vtype, err)
-		}
+	if err := client.CreateVolume(ctx, VolumeName(realm, clusterName, vtype), labels); err != nil {
+		return fmt.Errorf("creating %s volume: %w", vtype, err)
 	}
 	return nil
 }

--- a/pkg/cluster/resources_test.go
+++ b/pkg/cluster/resources_test.go
@@ -26,7 +26,7 @@ func TestClusterResourceLifecycle(t *testing.T) {
 	if !rec.IsIntegration() {
 		// CreateClusterNetwork
 		rec.AddResult("net-id\n", "", nil)
-		// CreateClusterVolumes (config, munge, data)
+		// CreateClusterVolume × 3 (config, munge, data)
 		rec.AddResult("", "", nil)
 		rec.AddResult("", "", nil)
 		rec.AddResult("", "", nil)
@@ -65,8 +65,10 @@ func TestClusterResourceLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create volumes.
-	err = CreateClusterVolumes(ctx, c, mesh.DefaultRealm, clusterName, true)
-	require.NoError(t, err)
+	for _, vtype := range []VolumeType{VolumeConfig, VolumeMunge, VolumeData} {
+		err = CreateClusterVolume(ctx, c, mesh.DefaultRealm, clusterName, vtype)
+		require.NoError(t, err)
+	}
 
 	// Write config.
 	helperImage := "busybox:latest"
@@ -131,64 +133,34 @@ func TestCreateClusterNetwork_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "creating cluster network")
 }
 
-// --- CreateClusterVolumes ---
+// --- CreateClusterVolume ---
 
-func TestCreateClusterVolumes(t *testing.T) {
+func TestCreateClusterVolume(t *testing.T) {
 	var m mock.Executor
-	m.AddResult("", "", nil) // config
-	m.AddResult("", "", nil) // munge
-	m.AddResult("", "", nil) // data
+	m.AddResult("", "", nil)
 	c := docker.NewClient(&m)
 
-	err := CreateClusterVolumes(t.Context(), c, mesh.DefaultRealm, "dev", true)
+	err := CreateClusterVolume(t.Context(), c, mesh.DefaultRealm, "dev", VolumeConfig)
 
 	require.NoError(t, err)
-	require.Len(t, m.Calls, 3)
+	require.Len(t, m.Calls, 1)
 	assert.Equal(t, []string{
 		"volume", "create",
 		"--label", "com.docker.compose.project=sind-dev",
 		"--label", "com.docker.compose.volume=config",
 		"sind-dev-config",
 	}, m.Calls[0].Args)
-	assert.Equal(t, []string{
-		"volume", "create",
-		"--label", "com.docker.compose.project=sind-dev",
-		"--label", "com.docker.compose.volume=munge",
-		"sind-dev-munge",
-	}, m.Calls[1].Args)
-	assert.Equal(t, []string{
-		"volume", "create",
-		"--label", "com.docker.compose.project=sind-dev",
-		"--label", "com.docker.compose.volume=data",
-		"sind-dev-data",
-	}, m.Calls[2].Args)
 }
 
-func TestCreateClusterVolumes_SkipData(t *testing.T) {
+func TestCreateClusterVolume_Error(t *testing.T) {
 	var m mock.Executor
-	m.AddResult("", "", nil) // config
-	m.AddResult("", "", nil) // munge
+	m.AddResult("", "", fmt.Errorf("volume create failed"))
 	c := docker.NewClient(&m)
 
-	err := CreateClusterVolumes(t.Context(), c, mesh.DefaultRealm, "dev", false)
-
-	require.NoError(t, err)
-	require.Len(t, m.Calls, 2)
-	assert.Contains(t, m.Calls[0].Args[len(m.Calls[0].Args)-1], "config")
-	assert.Contains(t, m.Calls[1].Args[len(m.Calls[1].Args)-1], "munge")
-}
-
-func TestCreateClusterVolumes_Error(t *testing.T) {
-	var m mock.Executor
-	m.AddResult("", "", nil)                                // config OK
-	m.AddResult("", "", fmt.Errorf("volume create failed")) // munge fails
-	c := docker.NewClient(&m)
-
-	err := CreateClusterVolumes(t.Context(), c, mesh.DefaultRealm, "dev", true)
+	err := CreateClusterVolume(t.Context(), c, mesh.DefaultRealm, "dev", VolumeMunge)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "munge")
-	assert.Len(t, m.Calls, 2)
 }
 
 // --- WriteClusterConfig ---

--- a/pkg/cluster/worker.go
+++ b/pkg/cluster/worker.go
@@ -146,13 +146,13 @@ func WorkerAdd(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager
 		}
 	}()
 
-	// Create and start node containers.
-	if err := createAllNodes(ctx, client, meshMgr, nodeConfigs); err != nil {
-		return nil, err
-	}
+	// Start event watcher before creating nodes.
+	prefix := ContainerPrefix(realm, opts.ClusterName)
+	watcher, stopWatcher := startWatcher(ctx, client, prefix, opts.ClusterName)
+	defer stopWatcher()
 
-	// Wait for readiness, inject SSH keys, collect host keys.
-	nodeResults, err := setupNodes(ctx, client, realm, opts.ClusterName, sshPubKey, nodeConfigs, readinessInterval)
+	// Create nodes, start systemd monitors, and wait for readiness.
+	nodeResults, err := setupNodes(ctx, client, meshMgr, realm, opts.ClusterName, sshPubKey, nodeConfigs, readinessInterval, watcher)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func WorkerAdd(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager
 		if err := updateNodesConf(ctx, client, controllerName, nodeConfigs); err != nil {
 			return nil, err
 		}
-		if err := enableSlurm(ctx, client, realm, opts.ClusterName, nodeConfigs, readinessInterval); err != nil {
+		if err := enableSlurm(ctx, client, realm, opts.ClusterName, nodeConfigs, readinessInterval, watcher); err != nil {
 			return nil, err
 		}
 	}
@@ -322,16 +322,20 @@ func nextWorkerIndexFromContainers(containers []docker.ContainerListEntry, realm
 // logged but not returned — this is best-effort cleanup.
 func cleanupWorkers(ctx context.Context, client *docker.Client, meshMgr *mesh.Manager, realm, clusterName string, nodeConfigs []RunConfig) {
 	log := sindlog.From(ctx)
+
+	dnsNames := make([]string, len(nodeConfigs))
+	for i, nc := range nodeConfigs {
+		dnsNames[i] = DNSName(nc.ShortName, clusterName, meshMgr.Realm)
+	}
+	if err := meshMgr.RemoveDNSRecords(ctx, dnsNames); err != nil {
+		log.DebugContext(ctx, "cleanup: removing DNS records", "error", err)
+	}
+	if err := meshMgr.RemoveKnownHosts(ctx, dnsNames); err != nil {
+		log.DebugContext(ctx, "cleanup: removing known hosts", "error", err)
+	}
+
 	for _, nc := range nodeConfigs {
 		containerName := ContainerName(realm, clusterName, nc.ShortName)
-		dnsName := DNSName(nc.ShortName, clusterName, meshMgr.Realm)
-
-		if err := meshMgr.RemoveDNSRecord(ctx, dnsName); err != nil {
-			log.DebugContext(ctx, "cleanup: removing DNS record", "node", nc.ShortName, "error", err)
-		}
-		if err := meshMgr.RemoveKnownHost(ctx, dnsName); err != nil {
-			log.DebugContext(ctx, "cleanup: removing known host", "node", nc.ShortName, "error", err)
-		}
 		logContainerDiagnostics(ctx, client, containerName)
 		if err := client.RemoveContainer(ctx, containerName); err != nil {
 			log.DebugContext(ctx, "cleanup: removing container", "node", nc.ShortName, "error", err)

--- a/pkg/cluster/worker_test.go
+++ b/pkg/cluster/worker_test.go
@@ -385,8 +385,12 @@ func workerAddOnCall(t *testing.T) func([]string, string) mock.Result {
 }
 
 func TestWorkerAdd_Managed(t *testing.T) {
+	pipes := &mock.Pipes{}
+	defer pipes.CloseAll()
+
 	var m mock.Executor
 	m.OnCall = workerAddOnCall(t)
+	m.OnStart = pipes.OnStart
 	client := docker.NewClient(&m)
 	mgr := mesh.NewManager(client, mesh.DefaultRealm)
 
@@ -524,16 +528,16 @@ func TestWorkerAdd_Unmanaged(t *testing.T) {
 		// Should not read/write sind-nodes.conf on controller
 		if args[0] == "exec" && args[1] == "sind-dev-controller" && len(args) > 2 && args[2] == "cat" &&
 			strings.Contains(joined, "sind-nodes.conf") {
-			t.Error("should not read sind-nodes.conf for unmanaged worker")
+			assert.Fail(t, "should not read sind-nodes.conf for unmanaged worker")
 		}
 		// Should not call scontrol reconfigure
 		if args[0] == "exec" && args[1] == "sind-dev-controller" && len(args) > 2 && args[2] == "scontrol" {
-			t.Error("should not call scontrol reconfigure for unmanaged worker")
+			assert.Fail(t, "should not call scontrol reconfigure for unmanaged worker")
 		}
 		// Should not enable slurmd on new node
 		if args[0] == "exec" && len(args) > 3 && strings.Contains(args[1], "worker-1") &&
 			args[2] == "systemctl" && args[3] == "enable" {
-			t.Error("should not enable slurmd for unmanaged worker")
+			assert.Fail(t, "should not enable slurmd for unmanaged worker")
 		}
 	}
 }
@@ -673,7 +677,7 @@ func TestWorkerRemove_Unmanaged(t *testing.T) {
 	for _, call := range m.Calls {
 		args := call.Args
 		if args[0] == "exec" && args[1] == "sind-dev-controller" && len(args) > 2 && args[2] == "scontrol" {
-			t.Error("should not call scontrol reconfigure for unmanaged removal")
+			assert.Fail(t, "should not call scontrol reconfigure for unmanaged removal")
 		}
 	}
 
@@ -937,7 +941,7 @@ func TestWorkerAdd_Unmanaged_MultipleNodes(t *testing.T) {
 	for _, call := range m.Calls {
 		args := call.Args
 		if args[0] == "exec" && args[1] == "sind-dev-controller" && len(args) > 2 && args[2] == "scontrol" {
-			t.Error("should not call scontrol reconfigure for unmanaged workers")
+			assert.Fail(t, "should not call scontrol reconfigure for unmanaged workers")
 		}
 	}
 }
@@ -983,7 +987,7 @@ func TestWorkerRemove_NoController(t *testing.T) {
 	for _, call := range m.Calls {
 		args := call.Args
 		if args[0] == "exec" && len(args) > 1 && args[1] == "sind-dev-controller" {
-			t.Error("should not interact with controller when it doesn't exist")
+			assert.Fail(t, "should not interact with controller when it doesn't exist")
 		}
 	}
 
@@ -1325,7 +1329,7 @@ func TestWorkerAdd_NoCleanupOnValidationFailure(t *testing.T) {
 	// No "docker rm" calls on worker containers → cleanup did not run.
 	for _, call := range m.Calls {
 		if call.Args[0] == "rm" && len(call.Args) >= 2 && strings.HasPrefix(call.Args[len(call.Args)-1], "sind-dev-worker-") {
-			t.Fatal("cleanup should not run when validation fails")
+			require.Fail(t, "cleanup should not run when validation fails")
 		}
 	}
 }

--- a/pkg/cmdexec/exec.go
+++ b/pkg/cmdexec/exec.go
@@ -19,6 +19,11 @@ type Executor interface {
 
 	// RunWithStdin is like Run but pipes the given reader to the command's stdin.
 	RunWithStdin(ctx context.Context, stdin io.Reader, name string, args ...string) (stdout string, stderr string, err error)
+
+	// Start starts a long-lived command and returns a Process for reading
+	// its stdout incrementally. The command is killed when ctx is cancelled.
+	// The caller must call Process.Close to release resources.
+	Start(ctx context.Context, name string, args ...string) (*Process, error)
 }
 
 // OSExecutor runs commands using os/exec.
@@ -42,4 +47,9 @@ func (e *OSExecutor) Run(ctx context.Context, name string, args ...string) (stri
 // RunWithStdin implements Executor.
 func (e *OSExecutor) RunWithStdin(ctx context.Context, stdin io.Reader, name string, args ...string) (string, string, error) {
 	return e.run(ctx, stdin, name, args...)
+}
+
+// Start implements Executor.
+func (e *OSExecutor) Start(ctx context.Context, name string, args ...string) (*Process, error) {
+	return Start(ctx, name, args...)
 }

--- a/pkg/cmdexec/exec_integration_test.go
+++ b/pkg/cmdexec/exec_integration_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+//go:build integration
+
+package cmdexec_test
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/GSI-HPC/sind/pkg/cmdexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOSExecutor_SimpleCommand(t *testing.T) {
+	var e cmdexec.OSExecutor
+	stdout, stderr, err := e.Run(t.Context(), "echo", "hello")
+	require.NoError(t, err)
+	assert.Equal(t, "hello\n", stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestOSExecutor_CapturesStderr(t *testing.T) {
+	var e cmdexec.OSExecutor
+	stdout, stderr, err := e.Run(t.Context(), "sh", "-c", "echo error >&2")
+	require.NoError(t, err)
+	assert.Empty(t, stdout)
+	assert.Equal(t, "error\n", stderr)
+}
+
+func TestOSExecutor_ExitError(t *testing.T) {
+	var e cmdexec.OSExecutor
+	_, _, err := e.Run(t.Context(), "sh", "-c", "exit 1")
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	assert.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+}
+
+func TestOSExecutor_ExitErrorPreservesOutput(t *testing.T) {
+	var e cmdexec.OSExecutor
+	stdout, stderr, err := e.Run(t.Context(), "sh", "-c", "echo out; echo err >&2; exit 2")
+	require.Error(t, err)
+	assert.Equal(t, "out\n", stdout)
+	assert.Equal(t, "err\n", stderr)
+}
+
+func TestOSExecutor_CommandNotFound(t *testing.T) {
+	var e cmdexec.OSExecutor
+	_, _, err := e.Run(t.Context(), "nonexistent-command-xyz")
+	require.Error(t, err)
+}
+
+func TestOSExecutor_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	var e cmdexec.OSExecutor
+	_, _, err := e.Run(ctx, "sleep", "10")
+	require.Error(t, err)
+}
+
+func TestOSExecutor_WithStdin(t *testing.T) {
+	var e cmdexec.OSExecutor
+	stdin := strings.NewReader("hello from stdin")
+	stdout, stderr, err := e.RunWithStdin(t.Context(), stdin, "cat")
+	require.NoError(t, err)
+	assert.Equal(t, "hello from stdin", stdout)
+	assert.Empty(t, stderr)
+}

--- a/pkg/cmdexec/exec_test.go
+++ b/pkg/cmdexec/exec_test.go
@@ -3,75 +3,14 @@
 package cmdexec_test
 
 import (
-	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/GSI-HPC/sind/internal/mock"
-	"github.com/GSI-HPC/sind/pkg/cmdexec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// --- OSExecutor ---
-
-func TestOSExecutor_SimpleCommand(t *testing.T) {
-	var e cmdexec.OSExecutor
-	stdout, stderr, err := e.Run(t.Context(), "echo", "hello")
-	require.NoError(t, err)
-	assert.Equal(t, "hello\n", stdout)
-	assert.Empty(t, stderr)
-}
-
-func TestOSExecutor_CapturesStderr(t *testing.T) {
-	var e cmdexec.OSExecutor
-	stdout, stderr, err := e.Run(t.Context(), "sh", "-c", "echo error >&2")
-	require.NoError(t, err)
-	assert.Empty(t, stdout)
-	assert.Equal(t, "error\n", stderr)
-}
-
-func TestOSExecutor_ExitError(t *testing.T) {
-	var e cmdexec.OSExecutor
-	_, _, err := e.Run(t.Context(), "sh", "-c", "exit 1")
-	require.Error(t, err)
-	var exitErr *exec.ExitError
-	assert.ErrorAs(t, err, &exitErr)
-	assert.Equal(t, 1, exitErr.ExitCode())
-}
-
-func TestOSExecutor_ExitErrorPreservesOutput(t *testing.T) {
-	var e cmdexec.OSExecutor
-	stdout, stderr, err := e.Run(t.Context(), "sh", "-c", "echo out; echo err >&2; exit 2")
-	require.Error(t, err)
-	assert.Equal(t, "out\n", stdout)
-	assert.Equal(t, "err\n", stderr)
-}
-
-func TestOSExecutor_CommandNotFound(t *testing.T) {
-	var e cmdexec.OSExecutor
-	_, _, err := e.Run(t.Context(), "nonexistent-command-xyz")
-	require.Error(t, err)
-}
-
-func TestOSExecutor_ContextCanceled(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
-	var e cmdexec.OSExecutor
-	_, _, err := e.Run(ctx, "sleep", "10")
-	require.Error(t, err)
-}
-
-func TestOSExecutor_WithStdin(t *testing.T) {
-	var e cmdexec.OSExecutor
-	stdin := strings.NewReader("hello from stdin")
-	stdout, stderr, err := e.RunWithStdin(t.Context(), stdin, "cat")
-	require.NoError(t, err)
-	assert.Equal(t, "hello from stdin", stdout)
-	assert.Empty(t, stderr)
-}
 
 // --- MockExecutor ---
 

--- a/pkg/cmdexec/logging.go
+++ b/pkg/cmdexec/logging.go
@@ -30,3 +30,9 @@ func (l *LoggingExecutor) RunWithStdin(ctx context.Context, stdin io.Reader, nam
 	l.Log(ctx, name+" "+strings.Join(args, " "))
 	return l.Inner.RunWithStdin(ctx, stdin, name, args...)
 }
+
+// Start implements Executor.
+func (l *LoggingExecutor) Start(ctx context.Context, name string, args ...string) (*Process, error) {
+	l.Log(ctx, name+" "+strings.Join(args, " "))
+	return l.Inner.Start(ctx, name, args...)
+}

--- a/pkg/cmdexec/logging_test.go
+++ b/pkg/cmdexec/logging_test.go
@@ -4,6 +4,7 @@ package cmdexec_test
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -44,4 +45,26 @@ func TestLoggingExecutor_RunWithStdin(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ok", stdout)
 	assert.Equal(t, "cmd arg", logged)
+}
+
+func TestLoggingExecutor_Start(t *testing.T) {
+	inner := &mock.Executor{
+		OnStart: func(_ []string) mock.StreamResult {
+			pr, pw := io.Pipe()
+			t.Cleanup(func() { _ = pw.Close() })
+			return mock.StreamResult{Reader: pr}
+		},
+	}
+
+	var logged string
+	l := &cmdexec.LoggingExecutor{
+		Inner: inner,
+		Log:   func(_ context.Context, cmd string) { logged = cmd },
+	}
+
+	proc, err := l.Start(t.Context(), "docker", "events")
+	require.NoError(t, err)
+	_ = proc.Close()
+
+	assert.Equal(t, "docker events", logged)
 }

--- a/pkg/cmdexec/stream.go
+++ b/pkg/cmdexec/stream.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package cmdexec
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"syscall"
+)
+
+// Process represents a running long-lived command whose stdout can be
+// read incrementally. The caller must call Close to release resources.
+type Process struct {
+	Stdout io.ReadCloser
+	cmd    *exec.Cmd
+}
+
+// Start starts a command and returns a Process for reading its stdout.
+// The command is killed when ctx is cancelled.
+func Start(ctx context.Context, name string, args ...string) (*Process, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdout.Close()
+		return nil, err
+	}
+	return &Process{Stdout: stdout, cmd: cmd}, nil
+}
+
+// Close kills the process (if still running) and waits for it to exit.
+// If the Process was created without a command (e.g. in tests), Close
+// just closes Stdout. The "signal: killed" error from the intentional
+// Kill is suppressed so normal shutdown returns nil.
+func (p *Process) Close() error {
+	if p.cmd == nil {
+		return p.Stdout.Close()
+	}
+	killed := false
+	if p.cmd.Process != nil {
+		if err := p.cmd.Process.Kill(); err == nil {
+			killed = true
+		}
+	}
+	err := p.cmd.Wait()
+	if killed && isKillSignalError(err) {
+		return nil
+	}
+	return err
+}
+
+// isKillSignalError reports whether err is the expected ExitError from
+// a process terminated by SIGKILL.
+func isKillSignalError(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return false
+	}
+	return status.Signaled() && status.Signal() == syscall.SIGKILL
+}

--- a/pkg/cmdexec/stream_integration_test.go
+++ b/pkg/cmdexec/stream_integration_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+//go:build integration
+
+package cmdexec_test
+
+import (
+	"bufio"
+	"context"
+	"testing"
+
+	"github.com/GSI-HPC/sind/pkg/cmdexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStart(t *testing.T) {
+	proc, err := cmdexec.Start(t.Context(), "echo", "hello")
+	require.NoError(t, err)
+	defer func() { _ = proc.Close() }()
+
+	scanner := bufio.NewScanner(proc.Stdout)
+	require.True(t, scanner.Scan(), "expected output line")
+	assert.Equal(t, "hello", scanner.Text())
+}
+
+func TestStart_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	proc, err := cmdexec.Start(ctx, "sleep", "60")
+	require.NoError(t, err)
+
+	cancel()
+	// Close kills a running process; the "signal: killed" ExitError
+	// from the intentional Kill should be suppressed.
+	assert.NoError(t, proc.Close())
+}
+
+func TestProcess_Close_KillsRunningProcess(t *testing.T) {
+	proc, err := cmdexec.Start(t.Context(), "sleep", "60")
+	require.NoError(t, err)
+	// Close should kill the running process and return nil, not
+	// "signal: killed".
+	assert.NoError(t, proc.Close())
+}
+
+func TestStart_InvalidCommand(t *testing.T) {
+	_, err := cmdexec.Start(t.Context(), "/nonexistent-binary-xyz")
+	require.Error(t, err)
+}
+
+func TestProcess_Close_WithCmd(t *testing.T) {
+	proc, err := cmdexec.Start(t.Context(), "echo", "done")
+	require.NoError(t, err)
+	_ = proc.Close()
+}
+
+func TestOSExecutor_Start(t *testing.T) {
+	var e cmdexec.OSExecutor
+	proc, err := e.Start(t.Context(), "echo", "hello")
+	require.NoError(t, err)
+	defer func() { _ = proc.Close() }()
+
+	scanner := bufio.NewScanner(proc.Stdout)
+	require.True(t, scanner.Scan(), "expected output line")
+	assert.Equal(t, "hello", scanner.Text())
+}

--- a/pkg/cmdexec/stream_test.go
+++ b/pkg/cmdexec/stream_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package cmdexec_test
+
+import (
+	"bufio"
+	"io"
+	"testing"
+
+	"github.com/GSI-HPC/sind/pkg/cmdexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcess_ReadStdout(t *testing.T) {
+	pr, pw := io.Pipe()
+	proc := &cmdexec.Process{Stdout: pr}
+
+	go func() {
+		_, _ = pw.Write([]byte("hello\n"))
+		_ = pw.Close()
+	}()
+
+	scanner := bufio.NewScanner(proc.Stdout)
+	require.True(t, scanner.Scan(), "expected output line")
+	assert.Equal(t, "hello", scanner.Text())
+	_ = proc.Close()
+}
+
+func TestProcess_Close_NilCmd(t *testing.T) {
+	pr, pw := io.Pipe()
+	proc := &cmdexec.Process{Stdout: pr}
+	_ = pw.Close()
+	err := proc.Close()
+	assert.NoError(t, err)
+}

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -269,6 +269,40 @@ func (m *Manager) AddDNSRecord(ctx context.Context, hostname, ip string) error {
 	return m.writeDNSEntries(ctx, entries)
 }
 
+// AddDNSRecords adds multiple A records to the mesh DNS Corefile and reloads
+// CoreDNS once. Existing entries for the same hostnames are replaced,
+// making the operation idempotent on retry.
+func (m *Manager) AddDNSRecords(ctx context.Context, records []DNSRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	entries, err := m.readDNSEntries(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Build set of hostnames being added for dedup.
+	newHostnames := make(map[string]bool, len(records))
+	for _, r := range records {
+		newHostnames[r.Hostname] = true
+	}
+
+	// Keep existing entries that don't conflict with new ones.
+	kept := make([]string, 0, len(entries)+len(records))
+	for _, entry := range entries {
+		fields := strings.Fields(entry)
+		if len(fields) >= 2 && newHostnames[fields[1]] {
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	for _, r := range records {
+		kept = append(kept, r.IP+" "+r.Hostname)
+	}
+
+	return m.writeDNSEntries(ctx, kept)
+}
+
 // RemoveDNSRecord removes all A records for the given hostname from the mesh DNS
 // Corefile and reloads CoreDNS.
 func (m *Manager) RemoveDNSRecord(ctx context.Context, hostname string) error {
@@ -281,6 +315,34 @@ func (m *Manager) RemoveDNSRecord(ctx context.Context, hostname string) error {
 	for _, entry := range entries {
 		fields := strings.Fields(entry)
 		if len(fields) >= 2 && fields[1] == hostname {
+			continue
+		}
+		kept = append(kept, entry)
+	}
+
+	return m.writeDNSEntries(ctx, kept)
+}
+
+// RemoveDNSRecords removes all A records for the given hostnames from the
+// mesh DNS Corefile and reloads CoreDNS once.
+func (m *Manager) RemoveDNSRecords(ctx context.Context, hostnames []string) error {
+	if len(hostnames) == 0 {
+		return nil
+	}
+	entries, err := m.readDNSEntries(ctx)
+	if err != nil {
+		return err
+	}
+
+	remove := make(map[string]bool, len(hostnames))
+	for _, h := range hostnames {
+		remove[h] = true
+	}
+
+	kept := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		fields := strings.Fields(entry)
+		if len(fields) >= 2 && remove[fields[1]] {
 			continue
 		}
 		kept = append(kept, entry)

--- a/pkg/mesh/mesh_test.go
+++ b/pkg/mesh/mesh_test.go
@@ -717,6 +717,137 @@ func TestAddDNSRecord_RestartError(t *testing.T) {
 	assert.Contains(t, err.Error(), "reloading DNS")
 }
 
+// --- AddDNSRecords (batch) ---
+
+func TestAddDNSRecords(t *testing.T) {
+	existing := []string{"172.18.0.2 controller.dev.sind.sind"}
+
+	var m mock.Executor
+	m.AddResult(corefileTar(t, existing), "", nil) // read
+	m.AddResult("", "", nil)                       // write
+	m.AddResult("sind-dns\n", "", nil)             // kill
+	m.AddResult("sind-dns\n", "", nil)             // start
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.AddDNSRecords(t.Context(), []DNSRecord{
+		{Hostname: "worker-0.dev.sind.sind", IP: "172.18.0.3"},
+		{Hostname: "worker-1.dev.sind.sind", IP: "172.18.0.4"},
+	})
+	require.NoError(t, err)
+
+	// Only 4 docker calls total (read, write, kill, start).
+	require.Len(t, m.Calls, 4)
+
+	corefile := extractTarFile(t, m.Calls[1].Stdin, "Corefile")
+	assert.Contains(t, corefile, "172.18.0.2 controller.dev.sind.sind")
+	assert.Contains(t, corefile, "172.18.0.3 worker-0.dev.sind.sind")
+	assert.Contains(t, corefile, "172.18.0.4 worker-1.dev.sind.sind")
+}
+
+func TestAddDNSRecords_Dedup(t *testing.T) {
+	existing := []string{
+		"172.18.0.2 controller.dev.sind.sind",
+		"172.18.0.3 worker-0.dev.sind.sind",
+	}
+
+	var m mock.Executor
+	m.AddResult(corefileTar(t, existing), "", nil) // read
+	m.AddResult("", "", nil)                       // write
+	m.AddResult("sind-dns\n", "", nil)             // kill
+	m.AddResult("sind-dns\n", "", nil)             // start
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	// Re-add controller with same IP — should replace, not duplicate.
+	err := mgr.AddDNSRecords(t.Context(), []DNSRecord{
+		{Hostname: "controller.dev.sind.sind", IP: "172.18.0.2"},
+	})
+	require.NoError(t, err)
+
+	corefile := extractTarFile(t, m.Calls[1].Stdin, "Corefile")
+	assert.Contains(t, corefile, "172.18.0.3 worker-0.dev.sind.sind")
+	assert.Contains(t, corefile, "172.18.0.2 controller.dev.sind.sind")
+	assert.Equal(t, 1, strings.Count(corefile, "controller.dev.sind.sind"),
+		"controller should appear exactly once")
+}
+
+func TestAddDNSRecords_ReadError(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("", "Error\n", fmt.Errorf("exit status 1"))
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.AddDNSRecords(t.Context(), []DNSRecord{
+		{Hostname: "controller.dev.sind.sind", IP: "172.18.0.2"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading DNS")
+}
+
+// --- RemoveDNSRecords (batch) ---
+
+func TestRemoveDNSRecords(t *testing.T) {
+	existing := []string{
+		"172.18.0.2 controller.dev.sind.sind",
+		"172.18.0.3 worker-0.dev.sind.sind",
+		"172.18.0.4 worker-1.dev.sind.sind",
+	}
+
+	var m mock.Executor
+	m.AddResult(corefileTar(t, existing), "", nil) // read
+	m.AddResult("", "", nil)                       // write
+	m.AddResult("sind-dns\n", "", nil)             // kill
+	m.AddResult("sind-dns\n", "", nil)             // start
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.RemoveDNSRecords(t.Context(), []string{
+		"controller.dev.sind.sind",
+		"worker-1.dev.sind.sind",
+	})
+	require.NoError(t, err)
+
+	// Only 4 docker calls total (read, write, kill, start).
+	require.Len(t, m.Calls, 4)
+
+	corefile := extractTarFile(t, m.Calls[1].Stdin, "Corefile")
+	assert.NotContains(t, corefile, "controller.dev.sind.sind")
+	assert.Contains(t, corefile, "172.18.0.3 worker-0.dev.sind.sind")
+	assert.NotContains(t, corefile, "worker-1.dev.sind.sind")
+}
+
+func TestRemoveDNSRecords_ReadError(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("", "Error\n", fmt.Errorf("exit status 1"))
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.RemoveDNSRecords(t.Context(), []string{"controller.dev.sind.sind"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading DNS")
+}
+
+func TestAddDNSRecords_Empty(t *testing.T) {
+	var m mock.Executor
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.AddDNSRecords(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, m.Calls, "no docker calls for empty slice")
+}
+
+func TestRemoveDNSRecords_Empty(t *testing.T) {
+	var m mock.Executor
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.RemoveDNSRecords(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, m.Calls, "no docker calls for empty slice")
+}
+
 // --- RemoveDNSRecord ---
 
 func TestRemoveDNSRecord(t *testing.T) {
@@ -1215,7 +1346,7 @@ func extractTarFile(t *testing.T, tarData, name string) string {
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
-			t.Fatalf("file %q not found in tar", name)
+			require.Failf(t, "file not found in tar", "%q", name)
 		}
 		require.NoError(t, err)
 		if hdr.Name == name {

--- a/pkg/mesh/ssh.go
+++ b/pkg/mesh/ssh.go
@@ -138,6 +138,102 @@ func (m *Manager) AddKnownHost(ctx context.Context, hostname, hostKey string) er
 	return nil
 }
 
+// KnownHostEntry holds a hostname and its SSH host key for batch registration.
+type KnownHostEntry struct {
+	Hostname string
+	HostKey  string
+}
+
+// AddKnownHosts adds host key entries to the known_hosts file. Existing
+// entries for the same hostnames are replaced, making the operation
+// idempotent on retry.
+func (m *Manager) AddKnownHosts(ctx context.Context, entries []KnownHostEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	name := m.SSHContainerName()
+	content, err := m.Docker.ReadFile(ctx, name, knownHostsPath)
+	if err != nil {
+		return fmt.Errorf("reading known_hosts: %w", err)
+	}
+
+	// Build set of hostnames being added for dedup.
+	newHostnames := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		newHostnames[e.Hostname] = true
+	}
+
+	// Keep existing lines that don't conflict with new entries.
+	lines := strings.Split(content, "\n")
+	var buf strings.Builder
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 1 && newHostnames[fields[0]] {
+			continue
+		}
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+	for _, e := range entries {
+		buf.WriteString(e.Hostname)
+		buf.WriteByte(' ')
+		buf.WriteString(e.HostKey)
+		buf.WriteByte('\n')
+	}
+
+	err = m.Docker.WriteFile(ctx, name, knownHostsPath, buf.String())
+	if err != nil {
+		return fmt.Errorf("writing known_hosts: %w", err)
+	}
+	return nil
+}
+
+// RemoveKnownHosts removes all entries for the given hostnames from the
+// known_hosts file in a single operation.
+func (m *Manager) RemoveKnownHosts(ctx context.Context, hostnames []string) error {
+	if len(hostnames) == 0 {
+		return nil
+	}
+	name := m.SSHContainerName()
+	content, err := m.Docker.ReadFile(ctx, name, knownHostsPath)
+	if err != nil {
+		return fmt.Errorf("reading known_hosts: %w", err)
+	}
+
+	remove := make(map[string]bool, len(hostnames))
+	for _, h := range hostnames {
+		remove[h] = true
+	}
+
+	lines := strings.Split(content, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 1 && remove[fields[0]] {
+			continue
+		}
+		kept = append(kept, line)
+	}
+
+	var result string
+	if len(kept) > 0 {
+		result = strings.Join(kept, "\n") + "\n"
+	}
+
+	err = m.Docker.WriteFile(ctx, name, knownHostsPath, result)
+	if err != nil {
+		return fmt.Errorf("writing known_hosts: %w", err)
+	}
+
+	return nil
+}
+
 // RemoveKnownHost removes all entries for the given hostname from the
 // known_hosts file in the SSH container.
 func (m *Manager) RemoveKnownHost(ctx context.Context, hostname string) error {

--- a/pkg/mesh/ssh_test.go
+++ b/pkg/mesh/ssh_test.go
@@ -398,6 +398,141 @@ func TestAddKnownHost_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "adding known host controller.dev.sind.sind")
 }
 
+// --- AddKnownHosts (batch) ---
+
+func TestAddKnownHosts(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("", "", nil) // ReadFile (empty known_hosts)
+	m.AddResult("", "", nil) // WriteFile
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.AddKnownHosts(t.Context(), []KnownHostEntry{
+		{Hostname: "controller.dev.sind.sind", HostKey: "ssh-ed25519 AAAA..."},
+		{Hostname: "worker-0.dev.sind.sind", HostKey: "ssh-ed25519 BBBB..."},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, m.Calls, 2)
+	assert.Equal(t,
+		"controller.dev.sind.sind ssh-ed25519 AAAA...\nworker-0.dev.sind.sind ssh-ed25519 BBBB...\n",
+		m.Calls[1].Stdin)
+}
+
+func TestAddKnownHosts_Dedup(t *testing.T) {
+	existing := "controller.dev.sind.sind ssh-ed25519 OLD-KEY\n" +
+		"worker-0.dev.sind.sind ssh-ed25519 BBBB...\n"
+
+	var m mock.Executor
+	m.AddResult(existing, "", nil) // ReadFile
+	m.AddResult("", "", nil)       // WriteFile
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.AddKnownHosts(t.Context(), []KnownHostEntry{
+		{Hostname: "controller.dev.sind.sind", HostKey: "ssh-ed25519 NEW-KEY"},
+	})
+	require.NoError(t, err)
+
+	// worker-0 preserved, controller replaced with new key.
+	assert.Equal(t,
+		"worker-0.dev.sind.sind ssh-ed25519 BBBB...\ncontroller.dev.sind.sind ssh-ed25519 NEW-KEY\n",
+		m.Calls[1].Stdin)
+}
+
+func TestAddKnownHosts_ReadError(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("", "", fmt.Errorf("container stopped"))
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.AddKnownHosts(t.Context(), []KnownHostEntry{
+		{Hostname: "controller.dev.sind.sind", HostKey: "ssh-ed25519 AAAA..."},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading known_hosts")
+}
+
+func TestAddKnownHosts_WriteError(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("", "", nil)                     // ReadFile
+	m.AddResult("", "", fmt.Errorf("disk full")) // WriteFile
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.AddKnownHosts(t.Context(), []KnownHostEntry{
+		{Hostname: "controller.dev.sind.sind", HostKey: "ssh-ed25519 AAAA..."},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing known_hosts")
+}
+
+func TestAddKnownHosts_Empty(t *testing.T) {
+	var m mock.Executor
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.AddKnownHosts(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, m.Calls, "no docker calls for empty slice")
+}
+
+// --- RemoveKnownHosts (batch) ---
+
+func TestRemoveKnownHosts(t *testing.T) {
+	existing := "controller.dev.sind.sind ssh-ed25519 AAAA...\n" +
+		"worker-0.dev.sind.sind ssh-ed25519 BBBB...\n" +
+		"worker-1.dev.sind.sind ssh-ed25519 CCCC...\n"
+
+	var m mock.Executor
+	m.AddResult(existing, "", nil) // ReadFile
+	m.AddResult("", "", nil)       // WriteFile
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.RemoveKnownHosts(t.Context(), []string{
+		"controller.dev.sind.sind",
+		"worker-1.dev.sind.sind",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, m.Calls, 2)
+	assert.Equal(t, "worker-0.dev.sind.sind ssh-ed25519 BBBB...\n", m.Calls[1].Stdin)
+}
+
+func TestRemoveKnownHosts_Empty(t *testing.T) {
+	var m mock.Executor
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.RemoveKnownHosts(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Empty(t, m.Calls, "no docker calls for empty slice")
+}
+
+func TestRemoveKnownHosts_ReadError(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("", "", fmt.Errorf("container stopped"))
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.RemoveKnownHosts(t.Context(), []string{"controller.dev.sind.sind"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading known_hosts")
+}
+
+func TestRemoveKnownHosts_WriteError(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("controller.dev.sind.sind ssh-ed25519 AAAA...\n", "", nil) // ReadFile
+	m.AddResult("", "", fmt.Errorf("disk full"))                           // WriteFile
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.RemoveKnownHosts(t.Context(), []string{"controller.dev.sind.sind"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing known_hosts")
+}
+
 // --- RemoveKnownHost ---
 
 func TestRemoveKnownHost(t *testing.T) {

--- a/pkg/monitor/docker.go
+++ b/pkg/monitor/docker.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package monitor
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/GSI-HPC/sind/pkg/docker"
+	sindlog "github.com/GSI-HPC/sind/pkg/log"
+)
+
+// dockerEvent is the JSON structure emitted by docker events --format '{{json .}}'.
+type dockerEvent struct {
+	Action string `json:"Action"`
+	Actor  struct {
+		Attributes map[string]string `json:"Attributes"`
+	} `json:"Actor"`
+	Time int64 `json:"time"`
+}
+
+// dockerActionMap maps docker event actions to EventKind values.
+var dockerActionMap = map[string]EventKind{
+	"start":   EventContainerStart,
+	"die":     EventContainerDie,
+	"oom":     EventContainerOOM,
+	"pause":   EventContainerPause,
+	"unpause": EventContainerUnpause,
+}
+
+// DockerMonitor reads a docker events JSON stream and emits Events.
+type DockerMonitor struct {
+	containerPrefix string
+}
+
+// NewDockerMonitor creates a monitor for the given cluster. The container
+// prefix is used to extract short node names from full container names.
+func NewDockerMonitor(containerPrefix string) *DockerMonitor {
+	return &DockerMonitor{containerPrefix: containerPrefix}
+}
+
+// Run reads from r (the stdout of docker events --format '{{json .}}')
+// and sends parsed events to ch. It blocks on scanner.Scan(), which is
+// not interruptible by context cancellation alone — to unblock Run on
+// ctx.Done(), the caller must also close r (e.g. by killing the
+// underlying process or closing the stdout pipe). The caller is
+// responsible for closing ch after Run returns.
+func (m *DockerMonitor) Run(ctx context.Context, r io.Reader, ch chan<- Event) error {
+	log := sindlog.From(ctx)
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		var de dockerEvent
+		if err := json.Unmarshal(scanner.Bytes(), &de); err != nil {
+			log.Log(ctx, sindlog.LevelTrace, "docker monitor: skipping unparseable line", "err", err)
+			continue
+		}
+
+		kind, ok := dockerActionMap[de.Action]
+		if !ok {
+			continue
+		}
+
+		name := de.Actor.Attributes["name"]
+		shortName, ok := m.extractShortName(name)
+		if !ok {
+			continue
+		}
+
+		ev := Event{
+			Kind:      kind,
+			Node:      shortName,
+			Container: docker.ContainerName(name),
+			Time:      time.Unix(de.Time, 0),
+		}
+
+		if kind == EventContainerDie {
+			ev.Detail = "exitCode=" + de.Actor.Attributes["exitCode"]
+		}
+
+		select {
+		case ch <- ev:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return scanner.Err()
+}
+
+// extractShortName extracts the short node name from a full container name
+// by stripping the container prefix. Returns false if the name does not
+// belong to this cluster.
+func (m *DockerMonitor) extractShortName(containerName string) (string, bool) {
+	if !strings.HasPrefix(containerName, m.containerPrefix) {
+		return "", false
+	}
+	short := strings.TrimPrefix(containerName, m.containerPrefix)
+	if short == "" {
+		return "", false
+	}
+	return short, true
+}
+
+// DockerEventsArgs returns the docker CLI arguments for streaming container
+// events for the given cluster.
+func DockerEventsArgs(clusterName string) []string {
+	return []string{
+		"events",
+		"--filter", "type=container",
+		"--filter", "label=sind.cluster=" + clusterName,
+		"--format", "{{json .}}",
+	}
+}

--- a/pkg/monitor/docker_test.go
+++ b/pkg/monitor/docker_test.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package monitor
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerMonitor_Run(t *testing.T) {
+	input := strings.Join([]string{
+		`{"Type":"container","Action":"start","Actor":{"Attributes":{"name":"sind-dev-controller","sind.cluster":"dev"}},"time":1234567890}`,
+		`{"Type":"container","Action":"die","Actor":{"Attributes":{"name":"sind-dev-worker-0","sind.cluster":"dev","exitCode":"137"}},"time":1234567891}`,
+		`{"Type":"container","Action":"oom","Actor":{"Attributes":{"name":"sind-dev-worker-1","sind.cluster":"dev"}},"time":1234567892}`,
+		`{"Type":"container","Action":"pause","Actor":{"Attributes":{"name":"sind-dev-controller","sind.cluster":"dev"}},"time":1234567893}`,
+		`{"Type":"container","Action":"unpause","Actor":{"Attributes":{"name":"sind-dev-controller","sind.cluster":"dev"}},"time":1234567894}`,
+	}, "\n")
+
+	m := NewDockerMonitor("sind-dev-")
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	require.Len(t, events, 5)
+
+	tests := []struct {
+		kind EventKind
+		node string
+	}{
+		{EventContainerStart, "controller"},
+		{EventContainerDie, "worker-0"},
+		{EventContainerOOM, "worker-1"},
+		{EventContainerPause, "controller"},
+		{EventContainerUnpause, "controller"},
+	}
+
+	for i, tt := range tests {
+		assert.Equal(t, tt.kind, events[i].Kind, "event[%d].Kind", i)
+		assert.Equal(t, tt.node, events[i].Node, "event[%d].Node", i)
+	}
+}
+
+func TestDockerMonitor_DieDetail(t *testing.T) {
+	input := `{"Type":"container","Action":"die","Actor":{"Attributes":{"name":"sind-dev-controller","exitCode":"1"}},"time":1234567890}` + "\n"
+	m := NewDockerMonitor("sind-dev-")
+	ch := make(chan Event, 10)
+
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	assert.Equal(t, "exitCode=1", events[0].Detail)
+}
+
+func TestDockerMonitor_SkipsUnknownActions(t *testing.T) {
+	input := `{"Type":"container","Action":"create","Actor":{"Attributes":{"name":"sind-dev-controller"}},"time":1234567890}` + "\n"
+	m := NewDockerMonitor("sind-dev-")
+	ch := make(chan Event, 10)
+
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events)
+}
+
+func TestDockerMonitor_SkipsForeignContainers(t *testing.T) {
+	input := `{"Type":"container","Action":"start","Actor":{"Attributes":{"name":"other-container"}},"time":1234567890}` + "\n"
+	m := NewDockerMonitor("sind-dev-")
+	ch := make(chan Event, 10)
+
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events)
+}
+
+func TestDockerMonitor_SkipsMalformedJSON(t *testing.T) {
+	input := "not json\n" +
+		`{"Type":"container","Action":"start","Actor":{"Attributes":{"name":"sind-dev-controller"}},"time":1234567890}` + "\n"
+	m := NewDockerMonitor("sind-dev-")
+	ch := make(chan Event, 10)
+
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	assert.Equal(t, EventContainerStart, events[0].Kind)
+}
+
+func TestDockerEventsArgs(t *testing.T) {
+	args := DockerEventsArgs("mycluster")
+	want := []string{
+		"events",
+		"--filter", "type=container",
+		"--filter", "label=sind.cluster=mycluster",
+		"--format", "{{json .}}",
+	}
+	assert.Equal(t, want, args)
+}
+
+func TestDockerMonitor_SkipsPrefixOnlyName(t *testing.T) {
+	input := `{"Type":"container","Action":"start","Actor":{"Attributes":{"name":"sind-dev-"}},"time":1234567890}` + "\n"
+	m := NewDockerMonitor("sind-dev-")
+	ch := make(chan Event, 10)
+
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events, "prefix-only name should be skipped")
+}
+
+func TestDockerMonitor_ContextCancelledMidScan(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	pr, pw := io.Pipe()
+	m := NewDockerMonitor("sind-dev-")
+	ch := make(chan Event, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.Run(ctx, pr, ch)
+	}()
+
+	// Write a valid event so the scanner reads one line.
+	_, _ = pw.Write([]byte(`{"Type":"container","Action":"start","Actor":{"Attributes":{"name":"sind-dev-controller"}},"time":1}` + "\n"))
+
+	// Drain the event so we know the loop iterated.
+	<-ch
+
+	// Cancel and close the pipe. The scanner.Scan() will return false
+	// on the next iteration because the pipe is closed.
+	cancel()
+	_ = pw.Close()
+
+	err := <-done
+	assert.NoError(t, err, "scanner sees EOF")
+}
+
+func TestDockerMonitor_ContextCancelledDuringSend(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	pr, pw := io.Pipe()
+	m := NewDockerMonitor("sind-dev-")
+	// Unbuffered channel — send will block.
+	ch := make(chan Event)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.Run(ctx, pr, ch)
+	}()
+
+	// Write an event. The send to ch will block because nobody reads.
+	_, _ = pw.Write([]byte(`{"Type":"container","Action":"start","Actor":{"Attributes":{"name":"sind-dev-controller"}},"time":1}` + "\n"))
+
+	// Cancel the context to unblock the select.
+	cancel()
+	_ = pw.Close()
+
+	err := <-done
+	// Either context.Canceled (cancel won the race) or nil (pipe EOF
+	// reached the scanner first) are valid outcomes.
+	if err != nil {
+		assert.ErrorIs(t, err, context.Canceled)
+	}
+}
+
+func drainEvents(ch <-chan Event) []Event {
+	var events []Event
+	for ev := range ch {
+		events = append(events, ev)
+	}
+	return events
+}

--- a/pkg/monitor/event.go
+++ b/pkg/monitor/event.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+// Package monitor provides event-driven monitoring of Docker containers
+// and systemd services inside them. It complements the poll-based probes
+// in pkg/probe by pushing state transitions through channels.
+package monitor
+
+import (
+	"time"
+
+	"github.com/GSI-HPC/sind/pkg/docker"
+)
+
+// EventKind identifies the category of a monitored event.
+type EventKind string
+
+// EventContainerStart indicates a container has started.
+const EventContainerStart EventKind = "container.start"
+
+// EventContainerDie indicates a container has exited.
+const EventContainerDie EventKind = "container.die"
+
+// EventContainerOOM indicates a container was killed by the OOM killer.
+const EventContainerOOM EventKind = "container.oom"
+
+// EventContainerPause indicates a container was paused.
+const EventContainerPause EventKind = "container.pause"
+
+// EventContainerUnpause indicates a container was unpaused.
+const EventContainerUnpause EventKind = "container.unpause"
+
+// EventUnitActive indicates a systemd unit reached ActiveState=active.
+const EventUnitActive EventKind = "unit.active"
+
+// EventUnitFailed indicates a systemd unit reached ActiveState=failed.
+const EventUnitFailed EventKind = "unit.failed"
+
+// EventMonitorError indicates an unrecoverable monitor failure.
+const EventMonitorError EventKind = "monitor.error"
+
+// Event represents a single state change observed by a monitor.
+type Event struct {
+	Kind      EventKind
+	Node      string               // short name: "controller", "worker-0"
+	Container docker.ContainerName // full container name
+	Unit      string               // systemd unit name (empty for container events)
+	Time      time.Time
+	Detail    string // human-readable detail (exit code, error message, etc.)
+	Err       error  // non-nil for EventMonitorError
+}
+
+// NodeTarget identifies a node to monitor.
+type NodeTarget struct {
+	ShortName string
+	Container docker.ContainerName
+}

--- a/pkg/monitor/event_test.go
+++ b/pkg/monitor/event_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package monitor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GSI-HPC/sind/pkg/docker"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventFields(t *testing.T) {
+	ev := Event{
+		Kind:      EventContainerStart,
+		Node:      "controller",
+		Container: docker.ContainerName("sind-dev-controller"),
+		Time:      time.Unix(1234567890, 0),
+		Detail:    "started",
+	}
+
+	assert.Equal(t, EventContainerStart, ev.Kind)
+	assert.Equal(t, "controller", ev.Node)
+	assert.Equal(t, docker.ContainerName("sind-dev-controller"), ev.Container)
+	assert.Empty(t, ev.Unit)
+	assert.NoError(t, ev.Err)
+}
+
+func TestNodeTarget(t *testing.T) {
+	nt := NodeTarget{
+		ShortName: "worker-0",
+		Container: docker.ContainerName("sind-dev-worker-0"),
+	}
+	assert.Equal(t, "worker-0", nt.ShortName)
+}

--- a/pkg/monitor/systemd.go
+++ b/pkg/monitor/systemd.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package monitor
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/GSI-HPC/sind/pkg/docker"
+	sindlog "github.com/GSI-HPC/sind/pkg/log"
+)
+
+// busctlSignal is the JSON structure emitted by busctl monitor --json=short
+// for PropertiesChanged signals on org.freedesktop.systemd1.
+type busctlSignal struct {
+	Type    string `json:"type"`
+	Path    string `json:"path"`
+	Member  string `json:"member"`
+	Payload struct {
+		Data json.RawMessage `json:"data"`
+	} `json:"payload"`
+	TimestampRealtime int64 `json:"timestamp-realtime"`
+}
+
+// SystemdMonitor reads busctl monitor output from inside a container
+// and emits Events for systemd unit state changes.
+type SystemdMonitor struct {
+	node      string
+	container docker.ContainerName
+}
+
+// NewSystemdMonitor creates a monitor for a single node container.
+func NewSystemdMonitor(node string, container docker.ContainerName) *SystemdMonitor {
+	return &SystemdMonitor{node: node, container: container}
+}
+
+// Run reads from r (the stdout of docker exec CONTAINER busctl monitor ...)
+// and sends parsed events to ch. It blocks on scanner.Scan(), which is
+// not interruptible by context cancellation alone — to unblock Run on
+// ctx.Done(), the caller must also close r (e.g. by killing the
+// underlying process or closing the stdout pipe). The caller is
+// responsible for closing ch after Run returns.
+func (m *SystemdMonitor) Run(ctx context.Context, r io.Reader, ch chan<- Event) error {
+	log := sindlog.From(ctx)
+	scanner := bufio.NewScanner(r)
+	// busctl JSON lines can be very long.
+	scanner.Buffer(make([]byte, 0, 64*1024), 512*1024)
+
+	for scanner.Scan() {
+		var sig busctlSignal
+		if err := json.Unmarshal(scanner.Bytes(), &sig); err != nil {
+			log.Log(ctx, sindlog.LevelTrace, "systemd monitor: skipping unparseable line", "err", err)
+			continue
+		}
+
+		if sig.Type != "signal" || sig.Member != "PropertiesChanged" {
+			continue
+		}
+
+		ev, ok := m.parsePropertiesChanged(sig)
+		if !ok {
+			continue
+		}
+
+		select {
+		case ch <- ev:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return scanner.Err()
+}
+
+// parsePropertiesChanged extracts an Event from a PropertiesChanged signal.
+// Returns false if the signal is not relevant (wrong interface, no state change).
+func (m *SystemdMonitor) parsePropertiesChanged(sig busctlSignal) (Event, bool) {
+	// The payload data is [interfaceName, changedProperties, invalidated].
+	var data []json.RawMessage
+	if err := json.Unmarshal(sig.Payload.Data, &data); err != nil || len(data) < 2 {
+		return Event{}, false
+	}
+
+	var iface string
+	if err := json.Unmarshal(data[0], &iface); err != nil {
+		return Event{}, false
+	}
+
+	if iface != "org.freedesktop.systemd1.Unit" {
+		return Event{}, false
+	}
+
+	props, err := parseChangedProperties(data[1])
+	if err != nil {
+		return Event{}, false
+	}
+
+	activeState, ok := props["ActiveState"]
+	if !ok {
+		return Event{}, false
+	}
+
+	ev := Event{
+		Node:      m.node,
+		Container: m.container,
+		Time:      time.UnixMicro(sig.TimestampRealtime),
+	}
+
+	switch activeState {
+	case "active":
+		ev.Kind = EventUnitActive
+	case "failed":
+		ev.Kind = EventUnitFailed
+	default:
+		return Event{}, false
+	}
+
+	unit := unitNameFromPath(sig.Path)
+	ev.Unit = unit
+	ev.Detail = "ActiveState=" + activeState
+
+	return ev, true
+}
+
+// parseChangedProperties extracts string-typed property values from the
+// D-Bus PropertiesChanged changed_properties map. The JSON structure is:
+//
+//	{"PropertyName": {"type": "s", "data": "value"}, ...}
+func parseChangedProperties(raw json.RawMessage) (map[string]string, error) {
+	var props map[string]struct {
+		Type string `json:"type"`
+		Data json.RawMessage
+	}
+	if err := json.Unmarshal(raw, &props); err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string, len(props))
+	for k, v := range props {
+		if v.Type != "s" {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(v.Data, &s); err != nil {
+			continue
+		}
+		result[k] = s
+	}
+	return result, nil
+}
+
+// unitNameFromPath extracts a systemd unit name from a D-Bus object path.
+// For example, /org/freedesktop/systemd1/unit/munge_2eservice becomes munge.service.
+func unitNameFromPath(path string) string {
+	const prefix = "/org/freedesktop/systemd1/unit/"
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	encoded := strings.TrimPrefix(path, prefix)
+	return dbusPathUnescape(encoded)
+}
+
+// dbusPathUnescape reverses systemd's D-Bus path escaping.
+// Underscores followed by two hex digits are replaced with the corresponding byte.
+// For example, _2e becomes '.', _2d becomes '-'.
+func dbusPathUnescape(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '_' && i+2 < len(s) {
+			hi := unhex(s[i+1])
+			lo := unhex(s[i+2])
+			if hi >= 0 && lo >= 0 {
+				b.WriteByte(byte(hi<<4 | lo))
+				i += 2
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+func unhex(c byte) int {
+	switch {
+	case '0' <= c && c <= '9':
+		return int(c - '0')
+	case 'a' <= c && c <= 'f':
+		return int(c - 'a' + 10)
+	case 'A' <= c && c <= 'F':
+		return int(c - 'A' + 10)
+	default:
+		return -1
+	}
+}
+
+// SystemdMonitorArgs returns the docker CLI arguments for streaming
+// systemd unit state changes from inside a container.
+func SystemdMonitorArgs(container docker.ContainerName) []string {
+	return []string{
+		"exec", string(container),
+		"busctl", "monitor",
+		"--watch-bind=yes",
+		"--json=short",
+		"--match", "type=signal,interface=org.freedesktop.DBus.Properties,member=PropertiesChanged,path_namespace=/org/freedesktop/systemd1",
+		"org.freedesktop.systemd1",
+	}
+}

--- a/pkg/monitor/systemd_test.go
+++ b/pkg/monitor/systemd_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package monitor
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/GSI-HPC/sind/pkg/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemdMonitor_UnitActive(t *testing.T) {
+	// Real busctl output for munge.service reaching ActiveState=active.
+	input := `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":516,"timestamp-realtime":1775658823092599,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit",{"ActiveState":{"type":"s","data":"active"},"SubState":{"type":"s","data":"running"}},["Conditions","Asserts"]]}}` + "\n"
+
+	m := NewSystemdMonitor("controller", "sind-dev-controller")
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+
+	ev := events[0]
+	assert.Equal(t, EventUnitActive, ev.Kind)
+	assert.Equal(t, "controller", ev.Node)
+	assert.Equal(t, "munge.service", ev.Unit)
+	assert.Equal(t, "ActiveState=active", ev.Detail)
+}
+
+func TestSystemdMonitor_UnitFailed(t *testing.T) {
+	input := `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/slurmd_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit",{"ActiveState":{"type":"s","data":"failed"}},["Conditions"]]}}` + "\n"
+
+	m := NewSystemdMonitor("worker-0", "sind-dev-worker-0")
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	assert.Equal(t, EventUnitFailed, events[0].Kind)
+	assert.Equal(t, "slurmd.service", events[0].Unit)
+}
+
+func TestSystemdMonitor_SkipsNonUnitInterface(t *testing.T) {
+	// PropertiesChanged on org.freedesktop.systemd1.Service (not .Unit).
+	input := `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Service",{"MainPID":{"type":"u","data":298}},["ExecStart"]]}}` + "\n"
+
+	m := NewSystemdMonitor("controller", "sind-dev-controller")
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events)
+}
+
+func TestSystemdMonitor_SkipsTransientStates(t *testing.T) {
+	// ActiveState=activating is transient, should be skipped.
+	input := `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit",{"ActiveState":{"type":"s","data":"activating"}},["Conditions"]]}}` + "\n"
+
+	m := NewSystemdMonitor("controller", "sind-dev-controller")
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events, "transient state should be skipped")
+}
+
+func TestSystemdMonitor_SkipsNonSignal(t *testing.T) {
+	input := `{"type":"method_call","path":"/foo","member":"Bar","payload":{"data":[]}}` + "\n"
+
+	m := NewSystemdMonitor("controller", "sind-dev-controller")
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events)
+}
+
+func TestSystemdMonitor_SkipsMalformedJSON(t *testing.T) {
+	input := "not json\n" +
+		`{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit",{"ActiveState":{"type":"s","data":"active"}},["Conditions"]]}}` + "\n"
+
+	m := NewSystemdMonitor("controller", "sind-dev-controller")
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	require.Len(t, events, 1, "malformed line skipped, valid line parsed")
+}
+
+func TestSystemdMonitor_SkipsNoActiveState(t *testing.T) {
+	// PropertiesChanged on .Unit but without ActiveState property.
+	input := `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit",{"SubState":{"type":"s","data":"running"}},["Conditions"]]}}` + "\n"
+
+	m := NewSystemdMonitor("controller", "sind-dev-controller")
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events)
+}
+
+func TestSystemdMonitor_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	pr, pw := io.Pipe()
+	m := NewSystemdMonitor("controller", "sind-dev-controller")
+	// Unbuffered channel — send blocks.
+	ch := make(chan Event)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.Run(ctx, pr, ch)
+	}()
+
+	// Write an event. The send will block.
+	_, _ = pw.Write([]byte(`{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit",{"ActiveState":{"type":"s","data":"active"}},["Conditions"]]}}` + "\n"))
+
+	cancel()
+	_ = pw.Close()
+
+	err := <-done
+	// Either context.Canceled (cancel won the race) or nil (pipe EOF
+	// reached the scanner first) are valid outcomes.
+	if err != nil {
+		assert.ErrorIs(t, err, context.Canceled)
+	}
+}
+
+func TestUnitNameFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/org/freedesktop/systemd1/unit/munge_2eservice", "munge.service"},
+		{"/org/freedesktop/systemd1/unit/slurmd_2eservice", "slurmd.service"},
+		{"/org/freedesktop/systemd1/unit/slurmctld_2eservice", "slurmctld.service"},
+		{"/org/freedesktop/systemd1/unit/systemd_2dtmpfiles_2dclean_2eservice", "systemd-tmpfiles-clean.service"},
+		{"/org/freedesktop/systemd1/unit/sshd_2eservice", "sshd.service"},
+		{"/org/freedesktop/systemd1", ""},
+		{"/other/path", ""},
+	}
+
+	for _, tt := range tests {
+		got := unitNameFromPath(tt.path)
+		assert.Equal(t, tt.want, got, "unitNameFromPath(%q)", tt.path)
+	}
+}
+
+func TestDbusPathUnescape(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"munge_2eservice", "munge.service"},
+		{"systemd_2dtmpfiles_2dclean_2eservice", "systemd-tmpfiles-clean.service"},
+		{"plain", "plain"},
+		{"_2F", "/"},         // uppercase hex
+		{"_2f", "/"},         // lowercase hex
+		{"trail_", "trail_"}, // incomplete escape at end
+		{"_zz", "_zz"},       // invalid hex digits
+	}
+
+	for _, tt := range tests {
+		got := dbusPathUnescape(tt.input)
+		assert.Equal(t, tt.want, got, "dbusPathUnescape(%q)", tt.input)
+	}
+}
+
+func TestSystemdMonitorArgs(t *testing.T) {
+	args := SystemdMonitorArgs("sind-dev-controller")
+	assert.Equal(t, "exec", args[0])
+	assert.Equal(t, "sind-dev-controller", args[1])
+	assert.Equal(t, "busctl", args[2])
+}
+
+func TestSystemdMonitor_SkipsMalformedPayloadData(t *testing.T) {
+	// payload.data is not a valid array.
+	input := `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":"notanarray"}}` + "\n"
+
+	m := NewSystemdMonitor("controller", docker.ContainerName("sind-dev-controller"))
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events)
+}
+
+func TestSystemdMonitor_SkipsMalformedInterfaceName(t *testing.T) {
+	// First element of data array is not a string.
+	input := `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":[42,{},["Conditions"]]}}` + "\n"
+
+	m := NewSystemdMonitor("controller", docker.ContainerName("sind-dev-controller"))
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events)
+}
+
+func TestSystemdMonitor_NonStringPropertiesIgnored(t *testing.T) {
+	// Unit interface with mixed property types — non-string properties should be
+	// silently ignored while ActiveState (string) is still extracted.
+	input := `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit",{"ActiveState":{"type":"s","data":"active"},"ConditionResult":{"type":"b","data":true},"Job":{"type":"(uo)","data":[0,"/"]}},["Conditions"]]}}` + "\n"
+
+	m := NewSystemdMonitor("controller", docker.ContainerName("sind-dev-controller"))
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	require.Len(t, events, 1)
+	assert.Equal(t, EventUnitActive, events[0].Kind)
+}
+
+func TestSystemdMonitor_SkipsMalformedStringData(t *testing.T) {
+	// Property claims type "s" but data is not a valid JSON string.
+	input := `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit",{"ActiveState":{"type":"s","data":42}},["Conditions"]]}}` + "\n"
+
+	m := NewSystemdMonitor("controller", docker.ContainerName("sind-dev-controller"))
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events)
+}
+
+func TestSystemdMonitor_SkipsMalformedProperties(t *testing.T) {
+	// Properties element is not a valid map.
+	input := `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit","notamap",["Conditions"]]}}` + "\n"
+
+	m := NewSystemdMonitor("controller", docker.ContainerName("sind-dev-controller"))
+	ch := make(chan Event, 10)
+	err := m.Run(t.Context(), strings.NewReader(input), ch)
+	require.NoError(t, err, "Run")
+	close(ch)
+
+	events := drainEvents(ch)
+	assert.Empty(t, events)
+}

--- a/pkg/monitor/watcher.go
+++ b/pkg/monitor/watcher.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package monitor
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/GSI-HPC/sind/pkg/cmdexec"
+	sindlog "github.com/GSI-HPC/sind/pkg/log"
+)
+
+// closeOnce wraps an io.ReadCloser so that Close can be called multiple
+// times safely. Only the first call actually closes the underlying reader.
+type closeOnce struct {
+	io.ReadCloser
+	once sync.Once
+	err  error
+}
+
+func (c *closeOnce) Close() error {
+	c.once.Do(func() { c.err = c.ReadCloser.Close() })
+	return c.err
+}
+
+// Watcher monitors a sind cluster for state changes across all nodes.
+// It manages the lifecycle of docker events and per-node systemd monitors,
+// and broadcasts events to subscribers.
+type Watcher struct {
+	executor    cmdexec.Executor
+	clusterName string
+	prefix      string
+
+	internalCh chan Event
+
+	mu          sync.Mutex
+	subscribers []chan Event
+
+	wg sync.WaitGroup
+}
+
+// NewWatcher creates a Watcher for the given cluster. The executor is used
+// to start long-lived streaming processes (docker events, busctl monitor).
+func NewWatcher(executor cmdexec.Executor, containerPrefix, clusterName string) *Watcher {
+	return &Watcher{
+		executor:    executor,
+		clusterName: clusterName,
+		prefix:      containerPrefix,
+		internalCh:  make(chan Event, 64),
+	}
+}
+
+// Subscribe returns a channel that receives a copy of every event.
+// The channel is closed when the Watcher stops. The caller should
+// drain the channel to avoid blocking the broadcast loop.
+func (w *Watcher) Subscribe() <-chan Event {
+	ch := make(chan Event, 64)
+	w.mu.Lock()
+	w.subscribers = append(w.subscribers, ch)
+	w.mu.Unlock()
+	return ch
+}
+
+// Unsubscribe removes a previously subscribed channel and closes it.
+func (w *Watcher) Unsubscribe(ch <-chan Event) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for i, sub := range w.subscribers {
+		if sub == ch {
+			w.subscribers = append(w.subscribers[:i], w.subscribers[i+1:]...)
+			close(sub)
+			return
+		}
+	}
+}
+
+// Start begins monitoring. It starts the docker events stream, spawns
+// systemd monitors for each given node, and starts the broadcast loop.
+// Cancel the context to stop all monitors.
+func (w *Watcher) Start(ctx context.Context, nodes []NodeTarget) error {
+	log := sindlog.From(ctx)
+
+	// Start docker events monitor.
+	dockerArgs := DockerEventsArgs(w.clusterName)
+	proc, err := w.executor.Start(ctx, "docker", dockerArgs...)
+	if err != nil {
+		log.Log(ctx, sindlog.LevelTrace, "failed to start docker events monitor", "err", err)
+		return err
+	}
+
+	dm := NewDockerMonitor(w.prefix)
+
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		defer func() { _ = proc.Close() }()
+		stdout := &closeOnce{ReadCloser: proc.Stdout}
+		runDone := make(chan struct{})
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			select {
+			case <-ctx.Done():
+			case <-runDone:
+			}
+			_ = stdout.Close()
+		}()
+		if err := dm.Run(ctx, stdout, w.internalCh); err != nil && ctx.Err() == nil {
+			select {
+			case w.internalCh <- Event{Kind: EventMonitorError, Err: err, Detail: "docker events stream failed"}:
+			case <-ctx.Done():
+			}
+		}
+		close(runDone)
+	}()
+
+	// Start systemd monitors for pre-existing nodes.
+	for _, node := range nodes {
+		w.startSystemdMonitor(ctx, node)
+	}
+
+	// Start broadcast loop.
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		w.broadcastLoop(ctx)
+	}()
+
+	return nil
+}
+
+// Wait blocks until all monitor goroutines have exited and closes
+// all remaining subscriber channels. Any Unsubscribe calls must complete
+// before Wait runs; otherwise a concurrent Unsubscribe would double-close
+// the channel Wait is iterating. Callers using the usual
+// defer watcher.Wait() / defer watcher.Unsubscribe(ch) pattern get this
+// ordering for free (deferred calls run LIFO).
+func (w *Watcher) Wait() {
+	w.wg.Wait()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, ch := range w.subscribers {
+		close(ch)
+	}
+	w.subscribers = nil
+}
+
+// AddNodes starts systemd monitors for the given nodes. Call this
+// after the node containers have been created so that systemd state
+// changes can accelerate readiness probing.
+func (w *Watcher) AddNodes(ctx context.Context, nodes []NodeTarget) {
+	for _, node := range nodes {
+		w.startSystemdMonitor(ctx, node)
+	}
+}
+
+func (w *Watcher) startSystemdMonitor(ctx context.Context, node NodeTarget) {
+	log := sindlog.From(ctx)
+	args := SystemdMonitorArgs(node.Container)
+	proc, err := w.executor.Start(ctx, "docker", args...)
+	if err != nil {
+		log.Log(ctx, sindlog.LevelTrace, "failed to start systemd monitor", "node", node.ShortName, "err", err)
+		select {
+		case w.internalCh <- Event{
+			Kind:      EventMonitorError,
+			Node:      node.ShortName,
+			Container: node.Container,
+			Err:       err,
+		}:
+		case <-ctx.Done():
+		}
+		return
+	}
+
+	sm := NewSystemdMonitor(node.ShortName, node.Container)
+
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		defer func() { _ = proc.Close() }()
+		stdout := &closeOnce{ReadCloser: proc.Stdout}
+		runDone := make(chan struct{})
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			select {
+			case <-ctx.Done():
+			case <-runDone:
+			}
+			_ = stdout.Close()
+		}()
+		if err := sm.Run(ctx, stdout, w.internalCh); err != nil && ctx.Err() == nil {
+			select {
+			case w.internalCh <- Event{
+				Kind:      EventMonitorError,
+				Node:      node.ShortName,
+				Container: node.Container,
+				Err:       err,
+				Detail:    "systemd monitor stream failed",
+			}:
+			case <-ctx.Done():
+			}
+		}
+		close(runDone)
+	}()
+}
+
+// broadcastLoop reads events from the internal channel and sends them
+// to all subscribers. It runs until the context is cancelled.
+func (w *Watcher) broadcastLoop(ctx context.Context) {
+	log := sindlog.From(ctx)
+	for {
+		select {
+		case ev := <-w.internalCh:
+			log.Log(ctx, sindlog.LevelTrace, "event", "kind", ev.Kind, "node", ev.Node, "unit", ev.Unit, "detail", ev.Detail)
+			w.mu.Lock()
+			for _, ch := range w.subscribers {
+				select {
+				case ch <- ev:
+				default:
+					// Subscriber is full — drop event to avoid blocking.
+					log.Log(ctx, sindlog.LevelTrace, "dropped event for full subscriber", "kind", ev.Kind, "node", ev.Node)
+				}
+			}
+			w.mu.Unlock()
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/pkg/monitor/watcher_test.go
+++ b/pkg/monitor/watcher_test.go
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+package monitor
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/GSI-HPC/sind/internal/mock"
+	"github.com/GSI-HPC/sind/pkg/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatcher_BroadcastsEvents(t *testing.T) {
+	pipes := &mock.Pipes{}
+	defer pipes.CloseAll()
+
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	sub := w.Subscribe()
+
+	nodes := []NodeTarget{{ShortName: "controller", Container: "sind-dev-controller"}}
+	err := w.Start(ctx, nodes)
+	require.NoError(t, err, "Start")
+
+	// Send a docker event (pipe 0 = docker events).
+	pipes.Write(0, `{"Type":"container","Action":"start","Actor":{"Attributes":{"name":"sind-dev-controller"}},"time":1}`+"\n")
+
+	select {
+	case ev := <-sub:
+		assert.Equal(t, EventContainerStart, ev.Kind)
+		assert.Equal(t, "controller", ev.Node)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+
+	cancel()
+	pipes.CloseAll()
+	w.Wait()
+}
+
+func TestWatcher_SystemdEvents(t *testing.T) {
+	pipes := &mock.Pipes{}
+	defer pipes.CloseAll()
+
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	sub := w.Subscribe()
+
+	nodes := []NodeTarget{{ShortName: "controller", Container: "sind-dev-controller"}}
+	err := w.Start(ctx, nodes)
+	require.NoError(t, err, "Start")
+
+	// Send a systemd event (pipe 1 = systemd monitor for controller).
+	pipes.Write(1, `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit",{"ActiveState":{"type":"s","data":"active"}},["Conditions"]]}}`+"\n")
+
+	select {
+	case ev := <-sub:
+		assert.Equal(t, EventUnitActive, ev.Kind)
+		assert.Equal(t, "munge.service", ev.Unit)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+
+	cancel()
+	pipes.CloseAll()
+	w.Wait()
+}
+
+func TestWatcher_AddNodes(t *testing.T) {
+	pipes := &mock.Pipes{}
+	defer pipes.CloseAll()
+
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	sub := w.Subscribe()
+
+	// Start with no nodes, then add one after.
+	err := w.Start(ctx, nil)
+	require.NoError(t, err, "Start")
+
+	w.AddNodes(ctx, []NodeTarget{{ShortName: "controller", Container: "sind-dev-controller"}})
+
+	// pipe 0 = docker events, pipe 1 = systemd monitor added via AddNodes.
+	pipes.Write(1, `{"type":"signal","endian":"l","flags":1,"version":1,"cookie":100,"timestamp-realtime":1000000,"sender":":1.1","path":"/org/freedesktop/systemd1/unit/munge_2eservice","interface":"org.freedesktop.DBus.Properties","member":"PropertiesChanged","payload":{"type":"sa{sv}as","data":["org.freedesktop.systemd1.Unit",{"ActiveState":{"type":"s","data":"active"}},["Conditions"]]}}`+"\n")
+
+	select {
+	case ev := <-sub:
+		assert.Equal(t, EventUnitActive, ev.Kind)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+
+	cancel()
+	pipes.CloseAll()
+	w.Wait()
+}
+
+func TestWatcher_MultipleSubscribers(t *testing.T) {
+	pipes := &mock.Pipes{}
+	defer pipes.CloseAll()
+
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	sub1 := w.Subscribe()
+	sub2 := w.Subscribe()
+
+	nodes := []NodeTarget{{ShortName: "controller", Container: "sind-dev-controller"}}
+	err := w.Start(ctx, nodes)
+	require.NoError(t, err, "Start")
+
+	pipes.Write(0, `{"Type":"container","Action":"start","Actor":{"Attributes":{"name":"sind-dev-controller"}},"time":1}`+"\n")
+
+	for i, sub := range []<-chan Event{sub1, sub2} {
+		select {
+		case ev := <-sub:
+			assert.Equal(t, EventContainerStart, ev.Kind, "subscriber %d", i)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("subscriber %d: timeout", i)
+		}
+	}
+
+	cancel()
+	pipes.CloseAll()
+	w.Wait()
+}
+
+func TestWatcher_Unsubscribe(t *testing.T) {
+	pipes := &mock.Pipes{}
+	defer pipes.CloseAll()
+
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	sub1 := w.Subscribe()
+	sub2 := w.Subscribe()
+	w.Unsubscribe(sub1)
+
+	nodes := []NodeTarget{{ShortName: "controller", Container: "sind-dev-controller"}}
+	err := w.Start(ctx, nodes)
+	require.NoError(t, err, "Start")
+
+	pipes.Write(0, `{"Type":"container","Action":"start","Actor":{"Attributes":{"name":"sind-dev-controller"}},"time":1}`+"\n")
+
+	select {
+	case ev := <-sub2:
+		assert.Equal(t, EventContainerStart, ev.Kind)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for event on sub2")
+	}
+
+	// sub1 should be closed after Unsubscribe.
+	_, ok := <-sub1
+	assert.False(t, ok, "sub1 should be closed after Unsubscribe")
+
+	cancel()
+	pipes.CloseAll()
+	w.Wait()
+}
+
+func TestWatcher_UnsubscribeNonexistent(_ *testing.T) {
+	m := &mock.Executor{}
+	w := NewWatcher(m, "sind-dev-", "dev")
+	other := make(chan Event)
+	w.Unsubscribe(other)
+}
+
+func TestWatcher_FullSubscriberDropsEvents(t *testing.T) {
+	pipes := &mock.Pipes{}
+	defer pipes.CloseAll()
+
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	sub := w.Subscribe()
+
+	nodes := []NodeTarget{{ShortName: "controller", Container: "sind-dev-controller"}}
+	err := w.Start(ctx, nodes)
+	require.NoError(t, err, "Start")
+
+	for i := range 70 {
+		pipes.Write(0, `{"Type":"container","Action":"start","Actor":{"Attributes":{"name":"sind-dev-controller"}},"time":`+
+			string(rune('0'+i%10))+`}`+"\n")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	drained := 0
+	for {
+		select {
+		case <-sub:
+			drained++
+		default:
+			goto done
+		}
+	}
+done:
+	assert.LessOrEqual(t, drained, 64, "expected at most 64 (buffer size)")
+
+	cancel()
+	pipes.CloseAll()
+	w.Wait()
+}
+
+func TestWatcher_SystemdMonitorStartFailure(t *testing.T) {
+	var dockerPW *io.PipeWriter
+	callCount := 0
+	m := &mock.Executor{
+		OnStart: func(_ []string) mock.StreamResult {
+			callCount++
+			if callCount == 1 {
+				pr, pw := io.Pipe()
+				dockerPW = pw
+				return mock.StreamResult{Reader: pr}
+			}
+			return mock.StreamResult{Err: errors.New("busctl not available")}
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	sub := w.Subscribe()
+
+	nodes := []NodeTarget{{ShortName: "controller", Container: docker.ContainerName("sind-dev-controller")}}
+	err := w.Start(ctx, nodes)
+	require.NoError(t, err, "Start")
+
+	select {
+	case ev := <-sub:
+		assert.Equal(t, EventMonitorError, ev.Kind)
+		assert.Equal(t, "controller", ev.Node)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for monitor error event")
+	}
+
+	cancel()
+	_ = dockerPW.Close()
+	w.Wait()
+}
+
+func TestWatcher_DockerMonitorRunFailure(t *testing.T) {
+	// When docker events stream fails mid-flight, an EventMonitorError
+	// should be emitted to subscribers.
+	pipes := &mock.Pipes{}
+	defer pipes.CloseAll()
+
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	sub := w.Subscribe()
+
+	err := w.Start(ctx, nil)
+	require.NoError(t, err, "Start")
+
+	// Close the docker events pipe writer with an error to simulate
+	// a stream failure. The scanner returns the pipe error.
+	pipes.CloseWithError(0, errors.New("connection reset"))
+
+	select {
+	case ev := <-sub:
+		assert.Equal(t, EventMonitorError, ev.Kind)
+		assert.Contains(t, ev.Detail, "docker events")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for monitor error event")
+	}
+
+	cancel()
+	w.Wait()
+}
+
+func TestWatcher_SystemdMonitorRunFailure(t *testing.T) {
+	pipes := &mock.Pipes{}
+	defer pipes.CloseAll()
+
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	sub := w.Subscribe()
+
+	nodes := []NodeTarget{{ShortName: "controller", Container: "sind-dev-controller"}}
+	err := w.Start(ctx, nodes)
+	require.NoError(t, err, "Start")
+
+	// Close the systemd monitor pipe (index 1) with an error.
+	pipes.CloseWithError(1, errors.New("container stopped"))
+
+	select {
+	case ev := <-sub:
+		assert.Equal(t, EventMonitorError, ev.Kind)
+		assert.Equal(t, "controller", ev.Node)
+		assert.Contains(t, ev.Detail, "systemd monitor")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for monitor error event")
+	}
+
+	cancel()
+	pipes.CloseAll()
+	w.Wait()
+}
+
+func TestWatcher_DockerMonitorStartFailure(t *testing.T) {
+	m := &mock.Executor{
+		OnStart: func(_ []string) mock.StreamResult {
+			return mock.StreamResult{Err: errors.New("docker not available")}
+		},
+	}
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	err := w.Start(t.Context(), nil)
+	require.Error(t, err)
+}
+
+func TestWatcher_WaitClosesSubscribers(t *testing.T) {
+	pipes := &mock.Pipes{}
+
+	m := &mock.Executor{OnStart: pipes.OnStart}
+	ctx, cancel := context.WithCancel(t.Context())
+
+	w := NewWatcher(m, "sind-dev-", "dev")
+	sub := w.Subscribe()
+
+	err := w.Start(ctx, nil)
+	require.NoError(t, err, "Start")
+
+	cancel()
+	pipes.CloseAll()
+	w.Wait()
+
+	_, ok := <-sub
+	assert.False(t, ok, "subscriber channel should be closed after Wait")
+}

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -13,6 +13,7 @@ import (
 	"github.com/GSI-HPC/sind/pkg/config"
 	"github.com/GSI-HPC/sind/pkg/docker"
 	sindlog "github.com/GSI-HPC/sind/pkg/log"
+	"github.com/GSI-HPC/sind/pkg/monitor"
 	"github.com/GSI-HPC/sind/pkg/slurm"
 )
 
@@ -100,6 +101,60 @@ func UntilReady(ctx context.Context, client *docker.Client, name docker.Containe
 		case <-ctx.Done():
 			return fmt.Errorf("node %s not ready: %w", name, lastErr)
 		case <-ticker.C:
+		}
+	}
+}
+
+// UntilReadyWithEvents is like UntilReady but also listens for events from
+// a monitor. Events trigger immediate probe re-evaluation instead of waiting
+// for the next poll interval, reducing detection latency for event-backed
+// state transitions. Container die events are treated as terminal errors.
+func UntilReadyWithEvents(ctx context.Context, client *docker.Client, name docker.ContainerName, probes []Probe, interval time.Duration, events <-chan monitor.Event) error {
+	log := sindlog.From(ctx)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	probeNames := make([]string, len(probes))
+	for i, p := range probes {
+		probeNames[i] = p.Name
+	}
+	log.DebugContext(ctx, "starting readiness probes (event-driven)", "node", string(name), "probes", strings.Join(probeNames, ","))
+
+	var lastErr error
+	for {
+		var failed bool
+		for _, p := range probes {
+			if err := p.Check(ctx, client, name); err != nil {
+				lastErr = fmt.Errorf("probe %s: %w", p.Name, err)
+				log.Log(ctx, sindlog.LevelTrace, "probe failed", "node", string(name), "probe", p.Name, "err", err)
+				failed = true
+				var te *TerminalError
+				if errors.As(err, &te) {
+					return fmt.Errorf("node %s not ready: %w", name, lastErr)
+				}
+				break
+			}
+		}
+		if !failed {
+			log.DebugContext(ctx, "all probes passed", "node", string(name))
+			return nil
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("node %s not ready: %w", name, lastErr)
+			case <-ticker.C:
+			case ev := <-events:
+				if ev.Kind == monitor.EventContainerDie && ev.Container == name {
+					return fmt.Errorf("node %s not ready: %w", name, &TerminalError{
+						Msg: fmt.Sprintf("container %s died: %s", name, ev.Detail),
+					})
+				}
+				if ev.Container != name {
+					continue
+				}
+			}
+			break
 		}
 	}
 }

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GSI-HPC/sind/internal/mock"
 	"github.com/GSI-HPC/sind/pkg/config"
 	"github.com/GSI-HPC/sind/pkg/docker"
+	"github.com/GSI-HPC/sind/pkg/monitor"
 	"github.com/GSI-HPC/sind/pkg/slurm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -448,4 +449,141 @@ func TestContainerRunning_OOMKilled(t *testing.T) {
 
 	var te *TerminalError
 	assert.ErrorAs(t, err, &te)
+}
+
+func TestUntilReadyWithEvents_AllPass(t *testing.T) {
+	var m mock.Executor
+	m.AddResult(inspectJSON("running"), "", nil)
+	c := docker.NewClient(&m)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	events := make(chan monitor.Event, 1)
+	probes := []Probe{{"container", ContainerRunning}}
+	err := UntilReadyWithEvents(ctx, c, testContainer, probes, time.Millisecond, events)
+	require.NoError(t, err)
+	assert.Len(t, m.Calls, 1)
+}
+
+func TestUntilReadyWithEvents_EventTriggersImmediateCheck(t *testing.T) {
+	var m mock.Executor
+	// First attempt: not running. Second attempt (triggered by event): running.
+	m.AddResult(inspectJSON("created"), "", nil)
+	m.AddResult(inspectJSON("running"), "", nil)
+	c := docker.NewClient(&m)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	events := make(chan monitor.Event, 1)
+	// Pre-load an event so the select picks it up instead of waiting for ticker.
+	events <- monitor.Event{Kind: monitor.EventContainerStart, Node: "controller", Container: testContainer}
+
+	probes := []Probe{{"container", ContainerRunning}}
+	// Use a very long interval so only the event can trigger the re-check.
+	err := UntilReadyWithEvents(ctx, c, testContainer, probes, time.Minute, events)
+	require.NoError(t, err)
+	assert.Len(t, m.Calls, 2)
+}
+
+func TestUntilReadyWithEvents_ContainerDie(t *testing.T) {
+	var m mock.Executor
+	// First attempt: not running.
+	m.AddResult(inspectJSON("created"), "", nil)
+	c := docker.NewClient(&m)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	events := make(chan monitor.Event, 1)
+	events <- monitor.Event{
+		Kind:      monitor.EventContainerDie,
+		Node:      "controller",
+		Container: testContainer,
+		Detail:    "exitCode=1",
+	}
+
+	probes := []Probe{{"container", ContainerRunning}}
+	err := UntilReadyWithEvents(ctx, c, testContainer, probes, time.Minute, events)
+	require.Error(t, err)
+
+	var te *TerminalError
+	assert.ErrorAs(t, err, &te)
+	assert.Contains(t, err.Error(), "not ready")
+	assert.Contains(t, err.Error(), "died")
+}
+
+func TestUntilReadyWithEvents_IgnoresOtherContainerEvents(t *testing.T) {
+	var m mock.Executor
+	// First attempt: not running. Second attempt (after ticker): running.
+	m.AddResult(inspectJSON("created"), "", nil)
+	m.AddResult(inspectJSON("running"), "", nil)
+	c := docker.NewClient(&m)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	events := make(chan monitor.Event, 1)
+	// Event for a different container — should be ignored.
+	events <- monitor.Event{
+		Kind:      monitor.EventContainerStart,
+		Node:      "worker-0",
+		Container: "sind-dev-worker-0",
+	}
+
+	probes := []Probe{{"container", ContainerRunning}}
+	// Short interval so the ticker fires after the ignored event.
+	err := UntilReadyWithEvents(ctx, c, testContainer, probes, time.Millisecond, events)
+	require.NoError(t, err)
+}
+
+func TestUntilReadyWithEvents_ContextCanceled(t *testing.T) {
+	var m mock.Executor
+	for range 100 {
+		m.AddResult(inspectJSON("created"), "", nil)
+	}
+	c := docker.NewClient(&m)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // already cancelled
+
+	events := make(chan monitor.Event)
+	probes := []Probe{{"container", ContainerRunning}}
+	err := UntilReadyWithEvents(ctx, c, testContainer, probes, time.Millisecond, events)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not ready")
+}
+
+func TestUntilReadyWithEvents_Timeout(t *testing.T) {
+	var m mock.Executor
+	for range 100 {
+		m.AddResult(inspectJSON("created"), "", nil)
+	}
+	c := docker.NewClient(&m)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	events := make(chan monitor.Event)
+	probes := []Probe{{"container", ContainerRunning}}
+	err := UntilReadyWithEvents(ctx, c, testContainer, probes, time.Millisecond, events)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not ready")
+}
+
+func TestUntilReadyWithEvents_TerminalError(t *testing.T) {
+	var m mock.Executor
+	m.AddResult(inspectJSON("exited"), "", nil)
+	c := docker.NewClient(&m)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	events := make(chan monitor.Event)
+	probes := []Probe{{"container", ContainerRunning}}
+	err := UntilReadyWithEvents(ctx, c, testContainer, probes, time.Millisecond, events)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exited")
+	assert.Len(t, m.Calls, 1)
 }


### PR DESCRIPTION
Add event-driven readiness monitoring to accelerate cluster creation and
optimize the full create/delete pipeline for better scaling.

**Event monitoring:**
- Docker events stream watches container start/die across the cluster
- Per-node systemd D-Bus monitors (`busctl monitor --watch-bind=yes`) detect
  unit state changes (sshd, slurmctld, slurmd becoming active)
- Events trigger immediate probe re-evaluation instead of waiting for the
  next poll tick; transparent fallback to poll-only mode

**Create pipeline optimizations:**
- Remove creation barrier: each node's create → monitor → probe runs as a
  single pipeline with no barrier between nodes
- Batch DNS registration: single Corefile read-write-restart for all nodes
- Batch known_hosts: single append for all host keys
- Parallel preflight checks via errgroup
- Flattened resource creation: network ║ (config vol → write) ║ (munge vol → write)
- Overlap registerMesh with enableSlurm (Slurm uses Docker embedded DNS)

**Delete pipeline optimizations:**
- Batch DNS and known_hosts removal (single read-filter-write per resource)
- Parallel container deletion via errgroup

**Other:**
- Troubleshooting docs for container exit 255 / inotify limits at scale
- Fix node count logging (`len(cfg.Nodes)` → actual expanded count)