### PR TITLE
test(doctor): seal doctor unit tests from real host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
+      - name: Install firejail
+        run: sudo apt-get update && sudo apt-get install -y firejail
+
+      # Prime the module cache outside the sandbox — firejail breaks DNS
+      # resolution, so `go test` must find every dependency pre-cached.
+      - name: Prime module cache
+        run: go mod download
+
       - name: Unit tests
         run: make test
         env:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,20 @@ CGO_ENABLED   ?= 0
 GOBUILD       ?= go build
 GOTEST        ?= go test
 
+# Sandbox for unit tests: blocks the host paths and service binaries the
+# doctor/mesh/docker/ssh code paths would otherwise read or exec, so a test
+# that forgets to inject a mock fs/executor trips a failure instead of
+# silently touching the runner. /bin/* and /usr/bin/* are both listed for
+# split-/usr portability; firejail ignores missing paths.
+FIREJAIL_TEST := firejail --quiet --noprofile \
+	--blacklist=/run/systemd \
+	--blacklist=/bin/systemctl --blacklist=/usr/bin/systemctl \
+	--blacklist=/bin/pkcheck --blacklist=/usr/bin/pkcheck \
+	--blacklist=/bin/resolvectl --blacklist=/usr/bin/resolvectl \
+	--blacklist=/bin/polkit-auth --blacklist=/usr/bin/polkit-auth \
+	--blacklist=/bin/docker --blacklist=/usr/bin/docker \
+	--blacklist=/bin/ssh --blacklist=/usr/bin/ssh
+
 .PHONY: build install lint lint-docs test test-integration coverage image clean help
 
 build: ## Build the sind binary
@@ -25,8 +39,8 @@ lint: ## Run golangci-lint
 lint-docs: ## Lint documentation markdown files
 	npx markdownlint-cli2 "docs/content/**/*.md"
 
-test: ## Run unit tests
-	$(GOTEST) -race ./...
+test: ## Run unit tests (sandboxed with firejail to catch host leaks)
+	$(FIREJAIL_TEST) -- $(GOTEST) -race ./...
 
 test-integration: ## Run integration tests (requires Docker)
 	$(GOTEST) -race -tags integration ./...

--- a/cmd/sind/context.go
+++ b/cmd/sind/context.go
@@ -11,6 +11,7 @@ import (
 	"github.com/GSI-HPC/sind/pkg/docker"
 	sindlog "github.com/GSI-HPC/sind/pkg/log"
 	"github.com/GSI-HPC/sind/pkg/mesh"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +20,21 @@ type contextKey int
 const (
 	clientKey contextKey = iota
 	meshMgrKey
+	fsKey
 )
+
+// withFs stores an afero.Fs in the context.
+func withFs(ctx context.Context, fs afero.Fs) context.Context {
+	return context.WithValue(ctx, fsKey, fs)
+}
+
+// fsFrom retrieves the afero.Fs from the context, falling back to the OS fs.
+func fsFrom(ctx context.Context) afero.Fs {
+	if fs, ok := ctx.Value(fsKey).(afero.Fs); ok {
+		return fs
+	}
+	return afero.NewOsFs()
+}
 
 // withClient stores a docker.Client in the context.
 func withClient(ctx context.Context, c *docker.Client) context.Context {

--- a/cmd/sind/context.go
+++ b/cmd/sind/context.go
@@ -50,6 +50,11 @@ func clientFrom(ctx context.Context) *docker.Client {
 	return docker.NewClient(&cmdexec.OSExecutor{})
 }
 
+// withMeshMgr stores a mesh.Manager in the context.
+func withMeshMgr(ctx context.Context, m *mesh.Manager) context.Context {
+	return context.WithValue(ctx, meshMgrKey, m)
+}
+
 // meshMgrFrom retrieves the mesh.Manager from the context,
 // falling back to creating one from the given client and realm.
 func meshMgrFrom(ctx context.Context, client *docker.Client, realm string) *mesh.Manager {

--- a/cmd/sind/doctor.go
+++ b/cmd/sind/doctor.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/GSI-HPC/sind/pkg/doctor"
 	sindlog "github.com/GSI-HPC/sind/pkg/log"
@@ -27,16 +28,16 @@ func runDoctor(cmd *cobra.Command) error {
 	client := clientFrom(ctx)
 	realm := realmFromFlag(cmd)
 	mgr := meshMgrFrom(ctx, client, realm)
-	var failed bool
+	var failures []string
 
 	// Check Docker Engine version.
 	version, err := client.ServerVersion(ctx)
 	if err != nil {
 		printResult(cmd, false, "Docker Engine: not reachable")
-		failed = true
+		failures = append(failures, "docker")
 	} else if vErr := doctor.CheckDockerVersion(version); vErr != nil {
 		printResult(cmd, false, "Docker Engine: %s", vErr)
-		failed = true
+		failures = append(failures, "docker")
 	} else {
 		printResult(cmd, true, "Docker Engine: %s (>= %d.0)", version, doctor.MinDockerMajor)
 	}
@@ -48,7 +49,7 @@ func runDoctor(cmd *cobra.Command) error {
 	log.Log(ctx, sindlog.LevelTrace, "cgroup2 check", "mountPath", mountPath, "v2", hasV2, "nsdelegate", hasNsd)
 	if !hasV2 {
 		printResult(cmd, false, "cgroup: v2 not mounted (sind requires cgroupv2)")
-		failed = true
+		failures = append(failures, "cgroup")
 	} else if !hasNsd {
 		printResult(cmd, false, "cgroupv2: nsdelegate not found")
 		cmd.Println()
@@ -62,7 +63,7 @@ func runDoctor(cmd *cobra.Command) error {
 		cmd.Println("echo -e '[Mount]\\nOptions=nsdelegate' \\")
 		cmd.Println("  | sudo tee /etc/systemd/system/sys-fs-cgroup.mount.d/nsdelegate.conf")
 		cmd.Println("sudo systemctl daemon-reload")
-		failed = true
+		failures = append(failures, "cgroup-nsdelegate")
 	} else {
 		printResult(cmd, true, "cgroupv2: nsdelegate enabled (%s)", mountPath)
 	}
@@ -110,8 +111,8 @@ func runDoctor(cmd *cobra.Command) error {
 		}
 	}
 
-	if failed {
-		return fmt.Errorf("one or more checks failed")
+	if len(failures) > 0 {
+		return fmt.Errorf("checks failed: %s", strings.Join(failures, ", "))
 	}
 	return nil
 }

--- a/cmd/sind/doctor.go
+++ b/cmd/sind/doctor.go
@@ -23,6 +23,7 @@ func newDoctorCommand() *cobra.Command {
 
 func runDoctor(cmd *cobra.Command) error {
 	ctx := cmd.Context()
+	fs := fsFrom(ctx)
 	client := clientFrom(ctx)
 	realm := realmFromFlag(cmd)
 	mgr := meshMgrFrom(ctx, client, realm)
@@ -43,7 +44,7 @@ func runDoctor(cmd *cobra.Command) error {
 	// Check cgroup2 with nsdelegate.
 	log := sindlog.From(ctx)
 	log.Log(ctx, sindlog.LevelTrace, "reading /proc/mounts for cgroup2 info")
-	mountPath, hasV2, hasNsd := doctor.CgroupInfo()
+	mountPath, hasV2, hasNsd := doctor.CgroupInfo(fs)
 	log.Log(ctx, sindlog.LevelTrace, "cgroup2 check", "mountPath", mountPath, "v2", hasV2, "nsdelegate", hasNsd)
 	if !hasV2 {
 		printResult(cmd, false, "cgroup: v2 not mounted (sind requires cgroupv2)")

--- a/cmd/sind/doctor_test.go
+++ b/cmd/sind/doctor_test.go
@@ -5,14 +5,60 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/GSI-HPC/sind/internal/mock"
 	"github.com/GSI-HPC/sind/pkg/docker"
 	"github.com/GSI-HPC/sind/pkg/mesh"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const validCgroupMounts = "cgroup2 /sys/fs/cgroup cgroup2 rw,nsdelegate 0 0\n"
+
+// errMeshDisabled stubs out DNS-advisory checks in doctor unit tests that do
+// not care about the mesh path — ResolvedActive returns false and the branch
+// is skipped.
+var errMeshDisabled = errors.New("mesh disabled in hermetic doctor test")
+
+// hermeticDoctorCtx builds a context for doctor unit tests that does not touch
+// the real host: it injects an afero memfs with a fake /proc/mounts
+// (cgroupv2+nsdelegate) and a mesh.Manager whose Exec is a caller-supplied
+// mock, or, when meshExec is nil, an always-erroring stub that disables the
+// DNS advisory branch entirely.
+func hermeticDoctorCtx(t *testing.T, dockerExec, meshExec *mock.Executor) context.Context {
+	return hermeticDoctorCtxWithMounts(t, dockerExec, meshExec, validCgroupMounts)
+}
+
+// hermeticDoctorCtxWithMounts is hermeticDoctorCtx with caller-chosen
+// /proc/mounts content, for testing cgroup failure paths.
+func hermeticDoctorCtxWithMounts(
+	t *testing.T,
+	dockerExec, meshExec *mock.Executor,
+	mounts string,
+) context.Context {
+	t.Helper()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/proc/mounts", []byte(mounts), 0o644))
+
+	if meshExec == nil {
+		meshExec = &mock.Executor{
+			OnCall: func(_ []string, _ string) mock.Result {
+				return mock.Result{Err: errMeshDisabled}
+			},
+		}
+	}
+	client := docker.NewClient(dockerExec)
+	mgr := mesh.NewManager(client, mesh.DefaultRealm)
+	mgr.Exec = meshExec
+
+	ctx := withClient(context.Background(), client)
+	ctx = withMeshMgr(ctx, mgr)
+	return withFs(ctx, fs)
+}
 
 func TestDoctorCommand_AllPass(t *testing.T) {
 	var m mock.Executor
@@ -23,9 +69,7 @@ func TestDoctorCommand_AllPass(t *testing.T) {
 	cmd.SetOut(out)
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"doctor"})
-
-	ctx := withClient(context.Background(), docker.NewClient(&m))
-	cmd.SetContext(ctx)
+	cmd.SetContext(hermeticDoctorCtx(t, &m, nil))
 
 	err := cmd.Execute()
 	require.NoError(t, err)
@@ -44,12 +88,11 @@ func TestDoctorCommand_DockerTooOld(t *testing.T) {
 	cmd.SetOut(out)
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"doctor"})
-
-	ctx := withClient(context.Background(), docker.NewClient(&m))
-	cmd.SetContext(ctx)
+	cmd.SetContext(hermeticDoctorCtx(t, &m, nil))
 
 	err := cmd.Execute()
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "docker")
 
 	output := out.String()
 	assert.Contains(t, output, "27.5.0")
@@ -66,12 +109,11 @@ func TestDoctorCommand_DockerNotReachable(t *testing.T) {
 	cmd.SetOut(out)
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"doctor"})
-
-	ctx := withClient(context.Background(), docker.NewClient(&m))
-	cmd.SetContext(ctx)
+	cmd.SetContext(hermeticDoctorCtx(t, &m, nil))
 
 	err := cmd.Execute()
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "docker")
 
 	output := out.String()
 	assert.Contains(t, output, "Docker Engine")
@@ -86,13 +128,44 @@ func TestDoctorCommand_UnparseableVersion(t *testing.T) {
 	cmd.SetOut(out)
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"doctor"})
-
-	ctx := withClient(context.Background(), docker.NewClient(&m))
-	cmd.SetContext(ctx)
+	cmd.SetContext(hermeticDoctorCtx(t, &m, nil))
 
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, out.String(), "unable to parse")
+}
+
+func TestDoctorCommand_CgroupMissing(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("29.0.0", "", nil) // docker version
+
+	cmd := NewRootCommand()
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"doctor"})
+	cmd.SetContext(hermeticDoctorCtxWithMounts(t, &m, nil, "tmpfs /tmp tmpfs rw 0 0\n"))
+
+	err := cmd.Execute()
+	require.EqualError(t, err, "checks failed: cgroup")
+	assert.Contains(t, out.String(), "v2 not mounted")
+}
+
+func TestDoctorCommand_CgroupNsdelegateMissing(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("29.0.0", "", nil) // docker version
+
+	cmd := NewRootCommand()
+	out := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"doctor"})
+	cmd.SetContext(hermeticDoctorCtxWithMounts(t, &m, nil,
+		"cgroup2 /sys/fs/cgroup cgroup2 rw 0 0\n"))
+
+	err := cmd.Execute()
+	require.EqualError(t, err, "checks failed: cgroup-nsdelegate")
+	assert.Contains(t, out.String(), "nsdelegate not found")
 }
 
 func TestDoctorCommand_DNSPolicyShown(t *testing.T) {
@@ -105,18 +178,12 @@ func TestDoctorCommand_DNSPolicyShown(t *testing.T) {
 	var m mock.Executor
 	m.AddResult("29.0.0", "", nil) // docker version
 
-	mgr := mesh.NewManager(docker.NewClient(&m), mesh.DefaultRealm)
-	mgr.Exec = &sys
-
 	cmd := NewRootCommand()
 	out := new(bytes.Buffer)
 	cmd.SetOut(out)
 	cmd.SetErr(new(bytes.Buffer))
 	cmd.SetArgs([]string{"doctor"})
-
-	ctx := withClient(context.Background(), docker.NewClient(&m))
-	ctx = context.WithValue(ctx, meshMgrKey, mgr)
-	cmd.SetContext(ctx)
+	cmd.SetContext(hermeticDoctorCtx(t, &m, &sys))
 
 	_ = cmd.Execute()
 	assert.Contains(t, out.String(), "DNS policy")

--- a/cmd/sind/mode_integration_test.go
+++ b/cmd/sind/mode_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/GSI-HPC/sind/pkg/cmdexec"
 	"github.com/GSI-HPC/sind/pkg/docker"
 	"github.com/GSI-HPC/sind/pkg/doctor"
+	"github.com/spf13/afero"
 )
 
 // testID is a per-process random suffix for unique resource names.
@@ -113,7 +114,7 @@ func checkPrerequisites(t *testing.T, c *docker.Client) {
 	if vErr := doctor.CheckDockerVersion(version); vErr != nil {
 		t.Skipf("%v", vErr)
 	}
-	_, _, hasNsd := doctor.CgroupInfo()
+	_, _, hasNsd := doctor.CgroupInfo(afero.NewOsFs())
 	if !hasNsd {
 		t.Skip("host cgroup mount lacks nsdelegate")
 	}

--- a/pkg/cluster/mode_integration_test.go
+++ b/pkg/cluster/mode_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/GSI-HPC/sind/pkg/docker"
 	"github.com/GSI-HPC/sind/pkg/doctor"
 	"github.com/GSI-HPC/sind/pkg/mesh"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -223,7 +224,7 @@ func checkPrerequisites(t *testing.T, c *docker.Client) {
 	if vErr := doctor.CheckDockerVersion(version); vErr != nil {
 		t.Skipf("%v", vErr)
 	}
-	_, _, hasNsd := doctor.CgroupInfo()
+	_, _, hasNsd := doctor.CgroupInfo(afero.NewOsFs())
 	if !hasNsd {
 		t.Skip("host cgroup mount lacks nsdelegate")
 	}

--- a/pkg/doctor/doctor.go
+++ b/pkg/doctor/doctor.go
@@ -5,9 +5,10 @@ package doctor
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/afero"
 )
 
 // MinDockerMajor is the minimum required Docker Engine major version.
@@ -47,13 +48,10 @@ func CheckDockerVersion(version string) error {
 	return nil
 }
 
-// procMountsPath is the path to the mount table file. Tests may override it.
-var procMountsPath = "/proc/mounts"
-
-// CgroupInfo reads /proc/mounts and returns the cgroup2 mount path,
+// CgroupInfo reads /proc/mounts from fs and returns the cgroup2 mount path,
 // whether cgroup2 is mounted at all, and whether nsdelegate is enabled.
-func CgroupInfo() (mountPath string, hasV2, hasNsdelegate bool) {
-	data, err := os.ReadFile(procMountsPath)
+func CgroupInfo(fs afero.Fs) (mountPath string, hasV2, hasNsdelegate bool) {
+	data, err := afero.ReadFile(fs, "/proc/mounts")
 	if err != nil {
 		return "", false, false
 	}

--- a/pkg/doctor/doctor_test.go
+++ b/pkg/doctor/doctor_test.go
@@ -5,6 +5,7 @@ package doctor
 import (
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,22 +60,19 @@ func TestCheckDockerVersion_Invalid(t *testing.T) {
 	assert.Contains(t, err.Error(), "unable to parse version")
 }
 
-func TestCgroupInfo(t *testing.T) {
-	mountPath, hasV2, hasNsd := CgroupInfo()
-	if !hasV2 {
-		t.Skip("no cgroup2 mount on this host")
-	}
-	assert.NotEmpty(t, mountPath)
-	// nsdelegate may or may not be set, just verify the function ran
-	_ = hasNsd
+func TestCgroupInfo_MemFs(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/proc/mounts",
+		[]byte("cgroup2 /sys/fs/cgroup cgroup2 rw,nsdelegate 0 0\n"), 0o644))
+
+	mountPath, hasV2, hasNsd := CgroupInfo(fs)
+	assert.Equal(t, "/sys/fs/cgroup", mountPath)
+	assert.True(t, hasV2)
+	assert.True(t, hasNsd)
 }
 
 func TestCgroupInfo_ReadError(t *testing.T) {
-	old := procMountsPath
-	procMountsPath = "/nonexistent/mounts"
-	t.Cleanup(func() { procMountsPath = old })
-
-	path, hasV2, hasNsd := CgroupInfo()
+	path, hasV2, hasNsd := CgroupInfo(afero.NewMemMapFs())
 	assert.Empty(t, path)
 	assert.False(t, hasV2)
 	assert.False(t, hasNsd)


### PR DESCRIPTION
Fixes the host leaks reported in #44.

- inject `afero.Fs` into `doctor.CgroupInfo` (replacing the `procMountsPath` package global) so unit tests can feed a memfs `/proc/mounts`
- add `cmd/sind` `withFs` / `withMeshMgr` context helpers mirroring `withClient`
- add a `hermeticDoctorCtx` test helper that wires every `TestDoctorCommand_*` to a memfs with fake `cgroup2+nsdelegate` mounts and a mocked `mesh.Manager`, so no test shells out to `systemctl` / `pkcheck` or reads the real host mount table
- surface which check failed in `runDoctor`'s error (`checks failed: docker, cgroup, ...`) and assert on the exact message in the new cgroup tests
- update `cmd/sind` and `pkg/cluster` integration tests to pass `afero.NewOsFs()` to the new `CgroupInfo` signature

Verified by running \`make test\` on a sandbox host with no \`cgroup2\` mount — the formerly-failing \`TestDoctorCommand_AllPass\` now passes hermetically.

Closes #44