### PR TITLE
build(image): bump slurm to 25.11.6

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -341,7 +341,7 @@ sind-dev-worker-10       dev       worker       worker-10.dev.sind.sind         
 ```
 $ sind get cluster dev
 CLUSTER   SLURM     STATUS (R/S/P/T)
-dev       25.11.4   running (3/0/0/3)
+dev       25.11.6   running (3/0/0/3)
 
 NETWORKS
 NAME             DRIVER   SUBNET           GATEWAY        STATUS
@@ -811,7 +811,7 @@ sind applies labels to containers for filtering and metadata:
 | `sind.realm` | `sind` | Realm namespace |
 | `sind.cluster` | `dev` | Cluster name |
 | `sind.role` | `worker` | Node role |
-| `sind.slurm.version` | `25.11.4` | Slurm version |
+| `sind.slurm.version` | `25.11.6` | Slurm version |
 | `sind.data.hostpath` | `/home/user/project` | Resolved data mount host path |
 
 ### Enter and Exec

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN tar xf prrte.tar.bz2 && \
 # ==============================================================================
 FROM builder-base AS slurm-builder
 
-ARG SLURM_VERSION=25.11.4
+ARG SLURM_VERSION=25.11.6
 
 # PMIx headers and libraries are needed for Slurm's PMIx launch plugin.
 COPY --from=pmix-builder /install/usr /usr
@@ -135,7 +135,7 @@ RUN dnf -y install \
 
 # Fetch the Slurm source tarball with integrity verification.
 # The checksum must be updated when SLURM_VERSION changes.
-ADD --checksum=sha256:237f515adcb37b99ff6cb3e1fa81691a5f7188e94c3b6b495858b4eaecf6531d \
+ADD --checksum=sha256:6695aee51a36799917a4db4b1d787610af926b27b17c2e4246bf14c0fd029664 \
     https://download.schedmd.com/slurm/slurm-${SLURM_VERSION}.tar.bz2 /tmp/slurm.tar.bz2
 
 # Configure and install Slurm into a staging root so only the built
@@ -193,7 +193,7 @@ RUN tar xf openmpi.tar.bz2 && \
 # ==============================================================================
 FROM quay.io/rockylinux/rockylinux:10
 
-ARG SLURM_VERSION=25.11.4
+ARG SLURM_VERSION=25.11.6
 ARG UCX_VERSION=1.20.0
 ARG PMIX_VERSION=6.1.0
 ARG PRRTE_VERSION=4.1.0

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -11,7 +11,7 @@ variable "IMAGE_NAME" {
 # Must match the ARG defaults in the Dockerfile. Pinned here because the
 # Dockerfile checksums are coupled to these exact versions.
 variable "SLURM_VERSION" {
-  default = "25.11.4"
+  default = "25.11.6"
 }
 
 variable "UCX_VERSION" {

--- a/docs/content/architecture/docker-resources.md
+++ b/docs/content/architecture/docker-resources.md
@@ -67,5 +67,5 @@ sind applies labels to containers for filtering and metadata:
 | `sind.realm` | `sind` | Realm namespace |
 | `sind.cluster` | `dev` | Cluster name |
 | `sind.role` | `worker` | Node role |
-| `sind.slurm.version` | `25.11.4` | Slurm version |
+| `sind.slurm.version` | `25.11.6` | Slurm version |
 | `sind.data.hostpath` | `/home/user/project` | Resolved data mount host path |

--- a/docs/content/architecture/slurm-config.md
+++ b/docs/content/architecture/slurm-config.md
@@ -91,7 +91,7 @@ sind discovers the Slurm version before creating any cluster resources by runnin
 
 ```bash
 docker run --rm <image> scontrol --version
-# Output: "slurm 25.11.4"
+# Output: "slurm 25.11.6"
 ```
 
 This happens once per unique image. The version is stored as a label on cluster resources (`sind.slurm.version`) and used for:

--- a/docs/content/usage/diagnostics.md
+++ b/docs/content/usage/diagnostics.md
@@ -78,7 +78,7 @@ Example output at `-vv` (colorized on interactive terminals):
 00:13:28.438 INFO ensuring mesh infrastructure realm=sind
 00:13:28.826 INFO creating cluster name=dev nodes=3
 00:13:28.921 DEBU preflight check passed
-00:13:29.382 INFO resolved infrastructure slurm=25.11.4
+00:13:29.382 INFO resolved infrastructure slurm=25.11.6
 00:13:30.149 DEBU cluster resources created
 00:13:30.621 DEBU waiting for node node=controller
 00:13:30.622 DEBU waiting for node node=worker-0
@@ -112,7 +112,7 @@ Displays detailed health information:
 
 ```
 CLUSTER   SLURM     STATUS (R/S/P/T)
-dev       25.11.4   running (3/0/0/3)
+dev       25.11.6   running (3/0/0/3)
 
 NETWORKS
 NAME             DRIVER   SUBNET           GATEWAY        STATUS

--- a/pkg/cluster/status_test.go
+++ b/pkg/cluster/status_test.go
@@ -541,15 +541,15 @@ func fullStatusOnCall(t *testing.T) func([]string, string) mock.Result {
 			return mock.Result{Stdout: testutil.NDJSON(
 				testutil.PsEntry{
 					ID: "a", Names: "sind-dev-controller", State: "running", Image: "img",
-					Labels: "sind.cluster=dev,sind.role=controller,sind.slurm.version=25.11.4",
+					Labels: "sind.cluster=dev,sind.role=controller,sind.slurm.version=25.11.6",
 				},
 				testutil.PsEntry{
 					ID: "b", Names: "sind-dev-worker-0", State: "running", Image: "img",
-					Labels: "sind.cluster=dev,sind.role=worker,sind.slurm.version=25.11.4",
+					Labels: "sind.cluster=dev,sind.role=worker,sind.slurm.version=25.11.6",
 				},
 				testutil.PsEntry{
 					ID: "c", Names: "sind-dev-worker-1", State: "running", Image: "img",
-					Labels: "sind.cluster=dev,sind.role=worker,sind.slurm.version=25.11.4",
+					Labels: "sind.cluster=dev,sind.role=worker,sind.slurm.version=25.11.6",
 				},
 			)}
 		}
@@ -604,7 +604,7 @@ func TestGetStatus_Full(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "dev", status.Name)
-	assert.Equal(t, "25.11.4", status.SlurmVersion)
+	assert.Equal(t, "25.11.6", status.SlurmVersion)
 	assert.Equal(t, StateRunning, status.State)
 
 	// Nodes sorted: controller, worker-0, worker-1.

--- a/pkg/slurm/version_test.go
+++ b/pkg/slurm/version_test.go
@@ -82,7 +82,7 @@ func TestDiscoverVersionLifecycle(t *testing.T) {
 	image := "ghcr.io/gsi-hpc/sind-node:latest"
 
 	if !rec.IsIntegration() {
-		rec.AddResult("slurm 25.11.4\n", "", nil)
+		rec.AddResult("slurm 25.11.6\n", "", nil)
 	}
 
 	version, err := DiscoverVersion(t.Context(), c, image, false)


### PR DESCRIPTION
Updates the sind-node image to ship Slurm 25.11.6 ([release notes](https://github.com/SchedMD/slurm/releases/tag/slurm-25-11-6-1)).

- update `SLURM_VERSION` default to `25.11.6` in `Dockerfile` and `docker-bake.hcl`
- update slurm source tarball sha256 checksum
- refresh docs and example labels to `25.11.6`

Closes #50