### PR TITLE
fix(cluster): tolerate partial mesh and cluster state during delete (#52)

### DIFF
--- a/pkg/cluster/create_test.go
+++ b/pkg/cluster/create_test.go
@@ -533,19 +533,20 @@ func TestCreate_CleansUpMeshWhenFreshlyCreated(t *testing.T) {
 	_, err := Create(ctx, client, meshMgr, createCfg(), time.Millisecond)
 
 	require.Error(t, err)
-	// Verify mesh cleanup ran: CleanupMesh calls ContainerExists (container inspect)
-	// for sind-ssh and sind-dns after the cluster cleanup's "docker ps" call.
-	var containerInspectAfterPs int
+	// Verify mesh cleanup ran: CleanupMesh issues `rm -f` for the mesh
+	// helpers after the cluster cleanup's "docker ps" call.
+	var meshRmAfterPs int
 	seenPs := false
 	for _, call := range m.Calls {
 		if len(call.Args) > 0 && call.Args[0] == "ps" {
 			seenPs = true
 		}
-		if seenPs && len(call.Args) >= 2 && call.Args[0] == "container" && call.Args[1] == "inspect" {
-			containerInspectAfterPs++
+		if seenPs && len(call.Args) >= 3 && call.Args[0] == "rm" && call.Args[1] == "-f" &&
+			(strings.Contains(call.Args[2], "sind-ssh") || strings.Contains(call.Args[2], "sind-dns")) {
+			meshRmAfterPs++
 		}
 	}
-	assert.GreaterOrEqual(t, containerInspectAfterPs, 1, "mesh cleanup should check mesh containers")
+	assert.GreaterOrEqual(t, meshRmAfterPs, 1, "mesh cleanup should remove mesh containers")
 }
 
 func TestCreate_SkipsMeshCleanupWhenPreExisting(t *testing.T) {
@@ -570,15 +571,16 @@ func TestCreate_SkipsMeshCleanupWhenPreExisting(t *testing.T) {
 	_, err := Create(ctx, client, meshMgr, createCfg(), time.Millisecond)
 
 	require.Error(t, err)
-	// After the "docker ps" cleanup call, there should be NO container inspect
-	// calls for mesh cleanup.
+	// After the "docker ps" cleanup call, there should be NO mesh-helper
+	// `rm -f` calls.
 	seenPs := false
 	for _, call := range m.Calls {
 		if len(call.Args) > 0 && call.Args[0] == "ps" {
 			seenPs = true
 			continue
 		}
-		if seenPs && len(call.Args) >= 2 && call.Args[0] == "container" && call.Args[1] == "inspect" {
+		if seenPs && len(call.Args) >= 3 && call.Args[0] == "rm" && call.Args[1] == "-f" &&
+			(strings.Contains(call.Args[2], "sind-ssh") || strings.Contains(call.Args[2], "sind-dns")) {
 			require.Fail(t, "mesh cleanup should not run when mesh was pre-existing")
 		}
 	}
@@ -629,14 +631,15 @@ func TestCreate_MeshCleanupOnResolveInfraFailure(t *testing.T) {
 	_, err := Create(t.Context(), client, meshMgr, createCfg(), time.Millisecond)
 
 	require.Error(t, err)
-	// Mesh cleanup should run: ContainerExists (container inspect) for mesh containers.
-	var meshInspects int
+	// Mesh cleanup should run: `rm -f` for mesh containers.
+	var meshRm int
 	for _, call := range m.Calls {
-		if len(call.Args) >= 2 && call.Args[0] == "container" && call.Args[1] == "inspect" {
-			meshInspects++
+		if len(call.Args) >= 3 && call.Args[0] == "rm" && call.Args[1] == "-f" &&
+			(strings.Contains(call.Args[2], "sind-ssh") || strings.Contains(call.Args[2], "sind-dns")) {
+			meshRm++
 		}
 	}
-	assert.GreaterOrEqual(t, meshInspects, 1, "mesh cleanup should run on resolveInfra failure")
+	assert.GreaterOrEqual(t, meshRm, 1, "mesh cleanup should run on resolveInfra failure")
 }
 
 func TestCreate_CleanupResourcesError(t *testing.T) {
@@ -681,8 +684,10 @@ func TestCreate_CleanupMeshError(t *testing.T) {
 			inCleanup = true
 			return mock.Result{Err: fmt.Errorf("systemctl failed")}, true
 		}
-		// Make mesh cleanup fail: ContainerExists errors for mesh containers.
-		if inCleanup && args[0] == "container" && args[1] == "inspect" {
+		// Make mesh cleanup fail: rm -f on a mesh container errors with a
+		// non-IsNotFound failure (real docker daemon issue).
+		if inCleanup && args[0] == "rm" && len(args) >= 3 && args[1] == "-f" &&
+			(strings.Contains(args[2], "sind-ssh") || strings.Contains(args[2], "sind-dns")) {
 			return mock.Result{Err: fmt.Errorf("docker daemon unavailable")}, true
 		}
 		return mock.Result{}, false

--- a/pkg/cluster/create_test.go
+++ b/pkg/cluster/create_test.go
@@ -977,8 +977,12 @@ func TestRegisterMesh_KnownHostError(t *testing.T) {
 		if args[0] == "cp" && args[1] == "-" {
 			return mock.Result{}
 		}
-		// SignalContainer
-		if args[0] == "kill" {
+		// InspectContainer (state check before DNS reload)
+		if args[0] == "inspect" && len(args) >= 2 && strings.Contains(args[1], "sind-dns") {
+			return mock.Result{Stdout: dnsRunningInspectJSON}
+		}
+		// SignalContainer / StartContainer
+		if args[0] == "kill" || args[0] == "start" {
 			return mock.Result{}
 		}
 		// AppendFile → ExecWithStdin (exec -i)

--- a/pkg/cluster/delete.go
+++ b/pkg/cluster/delete.go
@@ -80,9 +80,8 @@ func deleteClusterResources(ctx context.Context, client *docker.Client, meshMgr 
 	}
 
 	// Remove DNS records and known_hosts entries before deleting containers.
-	if err := DeregisterMesh(ctx, meshMgr, clusterName, res.Containers); err != nil {
-		return err
-	}
+	// Failures are logged inside DeregisterMesh; the teardown continues.
+	_ = DeregisterMesh(ctx, meshMgr, clusterName, res.Containers)
 
 	log.DebugContext(ctx, "removing containers", "count", len(res.Containers))
 	if err := DeleteContainers(ctx, client, res.Containers); err != nil {
@@ -105,50 +104,78 @@ func deleteClusterResources(ctx context.Context, client *docker.Client, meshMgr 
 	return nil
 }
 
-// DeleteContainers force-removes the given containers in parallel (docker rm -f).
+// DeleteContainers force-removes the given containers in parallel
+// (docker rm -f). A container that is already gone is logged and treated as
+// success — the caller asked for the resource removed, not for a particular
+// state transition.
 func DeleteContainers(ctx context.Context, client *docker.Client, containers []docker.ContainerListEntry) error {
+	log := sindlog.From(ctx)
 	g, gctx := errgroup.WithContext(ctx)
 	for _, c := range containers {
 		g.Go(func() error {
-			if err := client.RemoveContainer(gctx, c.Name); err != nil {
-				return fmt.Errorf("removing container %s: %w", c.Name, err)
+			err := client.RemoveContainer(gctx, c.Name)
+			if err == nil {
+				return nil
 			}
-			return nil
+			if docker.IsNotFound(err) {
+				log.WarnContext(gctx, "container already gone, skipping",
+					"name", string(c.Name))
+				return nil
+			}
+			return fmt.Errorf("removing container %s: %w", c.Name, err)
 		})
 	}
 	return g.Wait()
 }
 
-// DeleteNetwork removes the cluster network.
+// DeleteNetwork removes the cluster network. A network that is already gone
+// is logged and treated as success.
 func DeleteNetwork(ctx context.Context, client *docker.Client, name docker.NetworkName) error {
-	if err := client.RemoveNetwork(ctx, name); err != nil {
-		return fmt.Errorf("removing network %s: %w", name, err)
+	err := client.RemoveNetwork(ctx, name)
+	if err == nil {
+		return nil
 	}
-	return nil
+	if docker.IsNotFound(err) {
+		sindlog.From(ctx).WarnContext(ctx, "network already gone, skipping",
+			"name", string(name))
+		return nil
+	}
+	return fmt.Errorf("removing network %s: %w", name, err)
 }
 
 // DeleteVolumes removes the given cluster volumes. Each removal retries past
-// the dockerd async-cleanup race that follows `docker rm -f`.
+// the dockerd async-cleanup race that follows `docker rm -f`. A volume that
+// is already gone is logged and treated as success.
 func DeleteVolumes(ctx context.Context, client *docker.Client, volumes []docker.VolumeName) error {
+	log := sindlog.From(ctx)
 	for _, v := range volumes {
 		err := retry.Do(ctx,
 			func() error { return client.RemoveVolume(ctx, v) },
 			docker.IsVolumeInUse,
 			6, 100*time.Millisecond)
-		if err != nil {
-			return fmt.Errorf("removing volume %s: %w", v, err)
+		if err == nil {
+			continue
 		}
+		if docker.IsNotFound(err) {
+			log.WarnContext(ctx, "volume already gone, skipping", "name", string(v))
+			continue
+		}
+		return fmt.Errorf("removing volume %s: %w", v, err)
 	}
 	return nil
 }
 
 // DeregisterMesh removes DNS records and known_hosts entries for all
 // containers in batch. This is the inverse of registerMesh during cluster
-// creation.
+// creation. Failures are logged and swallowed: the cluster is being torn
+// down, and stale entries in a mesh helper that's already unreachable will
+// be overwritten on next register or cleared when the mesh itself is torn
+// down.
 func DeregisterMesh(ctx context.Context, meshMgr *mesh.Manager, clusterName string, containers []docker.ContainerListEntry) error {
 	if len(containers) == 0 {
 		return nil
 	}
+	log := sindlog.From(ctx)
 	prefix := ContainerPrefix(meshMgr.Realm, clusterName)
 	hostnames := make([]string, len(containers))
 	for i, c := range containers {
@@ -157,10 +184,10 @@ func DeregisterMesh(ctx context.Context, meshMgr *mesh.Manager, clusterName stri
 	}
 
 	if err := meshMgr.RemoveDNSRecords(ctx, hostnames); err != nil {
-		return fmt.Errorf("removing DNS records: %w", err)
+		log.WarnContext(ctx, "removing DNS records failed, continuing", "error", err)
 	}
 	if err := meshMgr.RemoveKnownHosts(ctx, hostnames); err != nil {
-		return fmt.Errorf("removing known hosts: %w", err)
+		log.WarnContext(ctx, "removing known_hosts entries failed, continuing", "error", err)
 	}
 	return nil
 }

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -189,8 +189,16 @@ func TestDeregisterMesh_KnownHostError(t *testing.T) {
 		if len(args) >= 2 && args[0] == "cp" && args[1] == "-" {
 			return mock.Result{}
 		}
+		// InspectContainer (state check) → running
+		if len(args) >= 2 && args[0] == "inspect" && strings.Contains(args[1], "sind-dns") {
+			return mock.Result{Stdout: dnsRunningInspectJSON}
+		}
 		// Signal DNS → success
 		if len(args) >= 2 && args[0] == "kill" {
+			return mock.Result{}
+		}
+		// Start DNS → success
+		if len(args) >= 2 && args[0] == "start" {
 			return mock.Result{}
 		}
 		// ReadFile (known_hosts via exec cat) → fail
@@ -450,6 +458,11 @@ func indexOf(slice []string, s string) int {
 	return -1
 }
 
+// dnsRunningInspectJSON is a mock docker inspect result reporting the
+// sind-dns container as running. Used by DeregisterMesh tests to satisfy the
+// container-state check that gates the DNS reload.
+const dnsRunningInspectJSON = `[{"Id":"dns123","Name":"/sind-dns","State":{"Status":"running"},"Config":{"Labels":{}},"NetworkSettings":{"Networks":{}}}]`
+
 // meshDeregisterOnCall returns a mock OnCall that handles RemoveDNSRecord
 // and RemoveKnownHost operations for DeregisterMesh tests.
 func meshDeregisterOnCall(knownHostsContent string) func([]string, string) mock.Result {
@@ -464,8 +477,14 @@ func meshDeregisterOnCall(knownHostsContent string) func([]string, string) mock.
 		// CopyToContainer: docker cp - sind-dns:/
 		case args[0] == "cp" && len(args) >= 2 && args[1] == "-":
 			return mock.Result{}
+		// InspectContainer: docker inspect sind-dns (state check before reload)
+		case args[0] == "inspect" && len(args) >= 2 && strings.Contains(args[1], "sind-dns"):
+			return mock.Result{Stdout: dnsRunningInspectJSON}
 		// Signal: docker kill -s HUP sind-dns
 		case args[0] == "kill":
+			return mock.Result{}
+		// Start: docker start sind-dns (DNS reload)
+		case args[0] == "start":
 			return mock.Result{}
 		// ReadFile: docker exec sind-ssh cat /root/.ssh/known_hosts
 		case args[0] == "exec" && len(args) >= 3 && args[2] == "cat":
@@ -586,8 +605,16 @@ func deleteOnCall(t *testing.T, exitErr *exec.ExitError, clusterName string, opt
 			}
 			return mock.Result{}
 
+		// docker inspect sind-dns (state check before DNS reload)
+		case args[0] == "inspect" && len(args) >= 2 && strings.Contains(args[1], "sind-dns"):
+			return mock.Result{Stdout: dnsRunningInspectJSON}
+
 		// docker kill -s HUP (DNS reload)
 		case args[0] == "kill":
+			return mock.Result{}
+
+		// docker start sind-dns (DNS reload)
+		case args[0] == "start":
 			return mock.Result{}
 
 		// docker exec (known_hosts read/write for DeregisterMesh or CleanupMesh)

--- a/pkg/cluster/delete_test.go
+++ b/pkg/cluster/delete_test.go
@@ -50,6 +50,23 @@ func TestDeleteContainers_RemoveError(t *testing.T) {
 	assert.Contains(t, err.Error(), "removing container sind-dev-controller")
 }
 
+// TestDeleteContainers_AlreadyGone covers the manual-cleanup case: the user
+// `docker rm`'d a cluster container, then ran `sind delete cluster`. The
+// removal must succeed with a warning instead of aborting.
+func TestDeleteContainers_AlreadyGone(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("", "Error: No such container\n", testutil.ExitCode1(t))
+	m.AddResult("", "", nil)
+	c := docker.NewClient(&m)
+
+	containers := []docker.ContainerListEntry{
+		{Name: "sind-dev-controller"},
+		{Name: "sind-dev-worker-0"},
+	}
+	err := DeleteContainers(t.Context(), c, containers)
+	require.NoError(t, err)
+}
+
 func TestDeleteContainers_Empty(t *testing.T) {
 	var m mock.Executor
 	c := docker.NewClient(&m)
@@ -85,6 +102,16 @@ func TestDeleteNetwork_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "removing network sind-dev-net")
 }
 
+// TestDeleteNetwork_AlreadyGone covers a network that was manually removed.
+func TestDeleteNetwork_AlreadyGone(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("", "Error: No such network\n", testutil.ExitCode1(t))
+	c := docker.NewClient(&m)
+
+	err := DeleteNetwork(t.Context(), c, docker.NetworkName("sind-dev-net"))
+	require.NoError(t, err)
+}
+
 // --- DeleteVolumes ---
 
 func TestDeleteVolumes(t *testing.T) {
@@ -115,6 +142,19 @@ func TestDeleteVolumes_Error(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "removing volume sind-dev-munge")
+}
+
+// TestDeleteVolumes_AlreadyGone covers volumes that were manually removed.
+func TestDeleteVolumes_AlreadyGone(t *testing.T) {
+	var m mock.Executor
+	m.AddResult("", "", nil)                                          // config OK
+	m.AddResult("", "Error: No such volume\n", testutil.ExitCode1(t)) // munge already gone
+	m.AddResult("", "", nil)                                          // data OK
+	c := docker.NewClient(&m)
+
+	volumes := []docker.VolumeName{"sind-dev-config", "sind-dev-munge", "sind-dev-data"}
+	err := DeleteVolumes(t.Context(), c, volumes)
+	require.NoError(t, err)
 }
 
 func TestDeleteVolumes_Empty(t *testing.T) {
@@ -157,6 +197,10 @@ func TestDeregisterMesh_Empty(t *testing.T) {
 	assert.Empty(t, m.Calls)
 }
 
+// TestDeregisterMesh_DNSError verifies that a DNS-side failure during
+// deregistration is logged and swallowed — the cluster is being torn down,
+// stale records are harmless, and aborting would prevent the rest of the
+// teardown from running.
 func TestDeregisterMesh_DNSError(t *testing.T) {
 	var m mock.Executor
 	m.OnCall = func(args []string, _ string) mock.Result {
@@ -173,9 +217,7 @@ func TestDeregisterMesh_DNSError(t *testing.T) {
 		{Name: "sind-dev-controller"},
 	}
 	err := DeregisterMesh(t.Context(), mgr, "dev", containers)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "removing DNS records")
+	require.NoError(t, err)
 }
 
 func TestDeregisterMesh_KnownHostError(t *testing.T) {
@@ -214,9 +256,7 @@ func TestDeregisterMesh_KnownHostError(t *testing.T) {
 		{Name: "sind-dev-controller"},
 	}
 	err := DeregisterMesh(t.Context(), mgr, "dev", containers)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "removing known hosts")
+	require.NoError(t, err)
 }
 
 // --- Delete Orchestrator ---
@@ -311,7 +351,11 @@ func TestDelete_ListResourcesError(t *testing.T) {
 	assert.Contains(t, err.Error(), "listing containers")
 }
 
-func TestDelete_DeregisterMeshError(t *testing.T) {
+// TestDelete_DeregisterMeshFailureContinues verifies that a failure during
+// DNS record removal does not abort the whole delete — the cluster is being
+// torn down and the orchestrator should continue removing containers,
+// network and volumes.
+func TestDelete_DeregisterMeshFailureContinues(t *testing.T) {
 	var m mock.Executor
 	exitErr := notFoundErr(t)
 	m.OnCall = deleteOnCall(t, exitErr, "dev", deleteOnCallOpts{
@@ -321,14 +365,27 @@ func TestDelete_DeregisterMeshError(t *testing.T) {
 		networkExists:  true,
 		volumes:        []string{"config", "munge", "data"},
 		deregisterFail: true,
+		otherClusters:  true, // skip CleanupMesh to keep the test focused
 	})
 	c := docker.NewClient(&m)
 	mgr := mesh.NewManager(c, mesh.DefaultRealm)
 
 	err := Delete(t.Context(), c, mgr, "dev")
+	require.NoError(t, err)
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "removing DNS record")
+	// Cluster container and network removal must have happened despite the
+	// failed DNS update.
+	var rmCount, netRm int
+	for _, call := range m.Calls {
+		switch {
+		case len(call.Args) >= 3 && call.Args[0] == "rm" && call.Args[1] == "-f":
+			rmCount++
+		case len(call.Args) >= 3 && call.Args[0] == "network" && call.Args[1] == "rm":
+			netRm++
+		}
+	}
+	assert.Equal(t, 1, rmCount, "container removed")
+	assert.Equal(t, 1, netRm, "network removed")
 }
 
 func TestDelete_ContainerRemoveError(t *testing.T) {
@@ -428,11 +485,13 @@ func TestDelete_CleanupMeshError(t *testing.T) {
 		volumes:       []string{"config"},
 		otherClusters: false,
 	})
-	// Override: make CleanupMesh's ContainerExists (container inspect) fail.
-	// The first container inspect in CleanupMesh is for the keygen container.
+	// Override: make CleanupMesh's first `rm -f` (for the SSH keygen container)
+	// fail with a real (non-IsNotFound) error.
 	inner := m.OnCall
+	rmSeen := false
 	m.OnCall = func(args []string, stdin string) mock.Result {
-		if args[0] == "container" && len(args) >= 3 && args[1] == "inspect" {
+		if !rmSeen && len(args) >= 3 && args[0] == "rm" && args[1] == "-f" {
+			rmSeen = true
 			return mock.Result{Err: fmt.Errorf("docker daemon unreachable")}
 		}
 		return inner(args, stdin)

--- a/pkg/cluster/worker_remove.go
+++ b/pkg/cluster/worker_remove.go
@@ -78,10 +78,9 @@ func WorkerRemove(ctx context.Context, client *docker.Client, meshMgr *mesh.Mana
 		// If ReadFile fails, sind-nodes.conf doesn't exist → treat as unmanaged.
 	}
 
-	// Deregister DNS + known_hosts.
-	if err := DeregisterMesh(ctx, meshMgr, clusterName, targets); err != nil {
-		return err
-	}
+	// Deregister DNS + known_hosts. Failures are logged inside DeregisterMesh;
+	// worker removal continues.
+	_ = DeregisterMesh(ctx, meshMgr, clusterName, targets)
 
 	// Stop + remove containers.
 	return DeleteContainers(ctx, client, targets)

--- a/pkg/cluster/worker_test.go
+++ b/pkg/cluster/worker_test.go
@@ -1525,7 +1525,10 @@ func TestWorkerRemove_RemoveNodesConfError(t *testing.T) {
 	assert.Contains(t, err.Error(), "updating sind-nodes.conf")
 }
 
-func TestWorkerRemove_DeregisterMeshError(t *testing.T) {
+// TestWorkerRemove_DeregisterMeshContinuesOnDNSFailure verifies that a DNS
+// update failure during worker removal is logged and swallowed — workers
+// should still be removed.
+func TestWorkerRemove_DeregisterMeshContinuesOnDNSFailure(t *testing.T) {
 	var m mock.Executor
 	inner := workerRemoveOnCall(t, "")
 	m.OnCall = func(args []string, stdin string) mock.Result {
@@ -1538,8 +1541,7 @@ func TestWorkerRemove_DeregisterMeshError(t *testing.T) {
 	mgr := mesh.NewManager(client, mesh.DefaultRealm)
 
 	err := WorkerRemove(t.Context(), client, mgr, "dev", []string{"worker-1"})
-
-	require.Error(t, err)
+	require.NoError(t, err)
 }
 
 // --- Lifecycle ---

--- a/pkg/cluster/worker_test.go
+++ b/pkg/cluster/worker_test.go
@@ -633,6 +633,9 @@ func workerRemoveOnCall(t *testing.T, nodesConf string) func([]string, string) m
 		// DNS: CopyToContainer / signal
 		case args[0] == "cp":
 			return mock.Result{}
+		// DNS: InspectContainer (state check before reload)
+		case args[0] == "inspect" && len(args) >= 2 && strings.Contains(args[1], "sind-dns"):
+			return mock.Result{Stdout: dnsRunningInspectJSON}
 		case args[0] == "kill":
 			return mock.Result{}
 
@@ -1022,7 +1025,9 @@ func TestWorkerRemove_NoController(t *testing.T) {
 			return mock.Result{Stdout: emptyCorefileTar()}
 		case args[0] == "cp":
 			return mock.Result{}
-		case args[0] == "kill":
+		case args[0] == "inspect" && len(args) >= 2 && strings.Contains(args[1], "sind-dns"):
+			return mock.Result{Stdout: dnsRunningInspectJSON}
+		case args[0] == "kill" || args[0] == "start":
 			return mock.Result{}
 		case args[0] == "exec" && args[1] == "sind-ssh":
 			return mock.Result{Stdout: "worker-0.dev.sind.sind ssh-ed25519 AAAA\n"}

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -455,6 +455,10 @@ func (m *Manager) readDNSEntries(ctx context.Context) ([]string, error) {
 
 // writeDNSEntries generates a new Corefile, writes it to the container, and
 // sends SIGHUP to reload CoreDNS.
+// writeDNSEntries generates a new Corefile and writes it to the DNS
+// container. If the container is running, it is restarted to pick up the new
+// configuration; if it is not running, the new Corefile will be loaded when
+// it next starts.
 func (m *Manager) writeDNSEntries(ctx context.Context, entries []string) error {
 	name := m.DNSContainerName()
 	err := m.Docker.CopyToContainer(ctx, name, "/", docker.FileContents{
@@ -462,6 +466,14 @@ func (m *Manager) writeDNSEntries(ctx context.Context, entries []string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("writing DNS Corefile: %w", err)
+	}
+
+	info, err := m.Docker.InspectContainer(ctx, name)
+	if err != nil {
+		return fmt.Errorf("inspecting DNS container: %w", err)
+	}
+	if info.Status != docker.StateRunning {
+		return nil
 	}
 
 	if err := m.Docker.KillContainer(ctx, name); err != nil {

--- a/pkg/mesh/mesh.go
+++ b/pkg/mesh/mesh.go
@@ -158,43 +158,39 @@ func (m *Manager) CleanupMesh(ctx context.Context) error {
 }
 
 // removeContainerIfExists stops and removes a container if it exists.
+// removeContainerIfExists removes a container, treating "not found" as
+// success so the delete path survives a TOCTOU race or a user-driven manual
+// removal.
 func (m *Manager) removeContainerIfExists(ctx context.Context, name docker.ContainerName) error {
-	exists, err := m.Docker.ContainerExists(ctx, name)
-	if err != nil {
+	if err := m.Docker.RemoveContainer(ctx, name); err != nil && !docker.IsNotFound(err) {
 		return err
 	}
-	if !exists {
-		return nil
-	}
-	return m.Docker.RemoveContainer(ctx, name)
+	return nil
 }
 
 // removeNetworkIfExists removes a network if it exists.
+// removeNetworkIfExists removes a network, treating "not found" as success.
 func (m *Manager) removeNetworkIfExists(ctx context.Context, name docker.NetworkName) error {
-	exists, err := m.Docker.NetworkExists(ctx, name)
-	if err != nil {
+	if err := m.Docker.RemoveNetwork(ctx, name); err != nil && !docker.IsNotFound(err) {
 		return err
 	}
-	if !exists {
-		return nil
-	}
-	return m.Docker.RemoveNetwork(ctx, name)
+	return nil
 }
 
 // removeVolumeIfExists removes a volume if it exists, retrying past the
 // dockerd async-cleanup race that follows `docker rm -f`.
+// removeVolumeIfExists removes a volume, retrying past the dockerd
+// async-cleanup race that follows `docker rm -f`, and treating "not found"
+// as success.
 func (m *Manager) removeVolumeIfExists(ctx context.Context, name docker.VolumeName) error {
-	exists, err := m.Docker.VolumeExists(ctx, name)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return nil
-	}
-	return retry.Do(ctx,
+	err := retry.Do(ctx,
 		func() error { return m.Docker.RemoveVolume(ctx, name) },
 		docker.IsVolumeInUse,
 		6, 100*time.Millisecond)
+	if err != nil && !docker.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 // Created reports whether EnsureMesh created new mesh infrastructure in this
@@ -455,6 +451,15 @@ func (m *Manager) readDNSEntries(ctx context.Context) ([]string, error) {
 
 // writeDNSEntries generates a new Corefile, writes it to the container, and
 // sends SIGHUP to reload CoreDNS.
+// writeDNSEntries generates a new Corefile and writes it to the DNS
+// container. If the container is running, it is restarted to pick up the new
+// configuration; if it is not running, the new Corefile will be loaded when
+// it next starts.
+// writeDNSEntries generates a new Corefile and writes it to the DNS
+// container. A missing DNS container is treated as a no-op (the mesh is
+// being torn down or the user removed it manually). A stopped container
+// has its Corefile updated but no reload kick; CoreDNS will load the new
+// config on next start.
 // writeDNSEntries generates a new Corefile and writes it to the DNS
 // container. If the container is running, it is restarted to pick up the new
 // configuration; if it is not running, the new Corefile will be loaded when

--- a/pkg/mesh/mesh_test.go
+++ b/pkg/mesh/mesh_test.go
@@ -70,16 +70,13 @@ func TestMeshLifecycle(t *testing.T) {
 		rec.AddResult("[{}]\n", "", nil) // SSH vol
 		rec.AddResult("[{}]\n", "", nil) // SSH
 
-		// CleanupMesh: remove keygen (gone), SSH, DNS, network, volume
-		rec.AddResult("", "Error\n", testutil.ExitCode1(t)) // keygen exists → no
-		rec.AddResult("[{}]\n", "", nil)                    // SSH exists
+		// CleanupMesh: direct rm -f / network rm / volume rm; missing keygen
+		// is swallowed via IsNotFound.
+		rec.AddResult("", "Error\n", testutil.ExitCode1(t)) // rm -f keygen → not found
 		rec.AddResult("sind-ssh\n", "", nil)                // rm -f SSH
-		rec.AddResult("[{}]\n", "", nil)                    // DNS exists
 		rec.AddResult("sind-dns\n", "", nil)                // rm -f DNS
-		rec.AddResult("[{}]\n", "", nil)                    // network exists
-		rec.AddResult("sind-mesh\n", "", nil)               // rm network
-		rec.AddResult("[{}]\n", "", nil)                    // SSH vol exists
-		rec.AddResult("sind-ssh-config\n", "", nil)         // rm SSH vol
+		rec.AddResult("sind-mesh\n", "", nil)               // network rm
+		rec.AddResult("sind-ssh-config\n", "", nil)         // volume rm
 
 		// Verify: all gone
 		rec.AddResult("", "Error\n", testutil.ExitCode1(t)) // network
@@ -314,19 +311,15 @@ func TestEnsureMesh_SSHContainerError(t *testing.T) {
 
 func TestCleanupMesh(t *testing.T) {
 	var m mock.Executor
-	// removeContainerIfExists(keygen): not found
+	// rm -f keygen: not found (swallowed)
 	m.AddResult("", "Error\n", testutil.ExitCode1(t))
-	// removeContainerIfExists(SSH): exists, rm -f
-	m.AddResult("[{}]\n", "", nil)
+	// rm -f SSH: success
 	m.AddResult("sind-ssh\n", "", nil)
-	// removeContainerIfExists(DNS): exists, rm -f
-	m.AddResult("[{}]\n", "", nil)
+	// rm -f DNS: success
 	m.AddResult("sind-dns\n", "", nil)
-	// removeNetworkIfExists: exists, remove
-	m.AddResult("[{}]\n", "", nil)
+	// network rm: success
 	m.AddResult("sind-mesh\n", "", nil)
-	// removeVolumeIfExists: exists, remove
-	m.AddResult("[{}]\n", "", nil)
+	// volume rm: success
 	m.AddResult("sind-ssh-config\n", "", nil)
 
 	c := docker.NewClient(&m)
@@ -335,21 +328,18 @@ func TestCleanupMesh(t *testing.T) {
 	err := mgr.CleanupMesh(t.Context())
 	require.NoError(t, err)
 
-	// Verify order: keygen container, SSH container, DNS container, network, volume.
-	assert.Equal(t, []string{"container", "inspect", "sind-ssh-keygen"}, m.Calls[0].Args)
-	assert.Equal(t, []string{"container", "inspect", string(SSHContainerName)}, m.Calls[1].Args)
-	assert.Equal(t, []string{"rm", "-f", string(SSHContainerName)}, m.Calls[2].Args)
-	assert.Equal(t, []string{"container", "inspect", string(DNSContainerName)}, m.Calls[3].Args)
-	assert.Equal(t, []string{"rm", "-f", string(DNSContainerName)}, m.Calls[4].Args)
-	assert.Equal(t, []string{"network", "inspect", string(NetworkName)}, m.Calls[5].Args)
-	assert.Equal(t, []string{"network", "rm", string(NetworkName)}, m.Calls[6].Args)
-	assert.Equal(t, []string{"volume", "inspect", string(SSHVolumeName)}, m.Calls[7].Args)
-	assert.Equal(t, []string{"volume", "rm", string(SSHVolumeName)}, m.Calls[8].Args)
+	// Verify order: keygen, SSH, DNS, network, volume.
+	require.Len(t, m.Calls, 5)
+	assert.Equal(t, []string{"rm", "-f", "sind-ssh-keygen"}, m.Calls[0].Args)
+	assert.Equal(t, []string{"rm", "-f", string(SSHContainerName)}, m.Calls[1].Args)
+	assert.Equal(t, []string{"rm", "-f", string(DNSContainerName)}, m.Calls[2].Args)
+	assert.Equal(t, []string{"network", "rm", string(NetworkName)}, m.Calls[3].Args)
+	assert.Equal(t, []string{"volume", "rm", string(SSHVolumeName)}, m.Calls[4].Args)
 }
 
 func TestCleanupMesh_NoneExist(t *testing.T) {
 	var m mock.Executor
-	// All five exist checks return not found (keygen, SSH, DNS, network, volume).
+	// All five remove ops return not found (IsNotFound, swallowed).
 	m.AddResult("", "Error\n", testutil.ExitCode1(t))
 	m.AddResult("", "Error\n", testutil.ExitCode1(t))
 	m.AddResult("", "Error\n", testutil.ExitCode1(t))
@@ -361,14 +351,14 @@ func TestCleanupMesh_NoneExist(t *testing.T) {
 
 	err := mgr.CleanupMesh(t.Context())
 	require.NoError(t, err)
-	assert.Len(t, m.Calls, 5) // only exist checks, no removes
+	assert.Len(t, m.Calls, 5)
 }
 
 func TestCleanupMesh_SSHContainerError(t *testing.T) {
 	var m mock.Executor
-	// keygen: not found
+	// keygen rm: not found (swallowed)
 	m.AddResult("", "Error\n", testutil.ExitCode1(t))
-	// SSH: connection refused
+	// SSH rm: real (non-IsNotFound) error
 	m.AddResult("", "", fmt.Errorf("connection refused"))
 	c := docker.NewClient(&m)
 	mgr := NewManager(c, DefaultRealm)
@@ -380,11 +370,11 @@ func TestCleanupMesh_SSHContainerError(t *testing.T) {
 
 func TestCleanupMesh_DNSContainerError(t *testing.T) {
 	var m mock.Executor
-	// keygen: not found
+	// keygen rm: not found (swallowed)
 	m.AddResult("", "Error\n", testutil.ExitCode1(t))
-	// SSH container doesn't exist
+	// SSH rm: not found (swallowed)
 	m.AddResult("", "Error\n", testutil.ExitCode1(t))
-	// DNS container check fails
+	// DNS rm: real (non-IsNotFound) error
 	m.AddResult("", "", fmt.Errorf("connection refused"))
 	c := docker.NewClient(&m)
 	mgr := NewManager(c, DefaultRealm)
@@ -396,10 +386,10 @@ func TestCleanupMesh_DNSContainerError(t *testing.T) {
 
 func TestCleanupMesh_NetworkError(t *testing.T) {
 	var m mock.Executor
-	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // keygen
-	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // SSH
-	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // DNS
-	m.AddResult("", "", fmt.Errorf("connection refused")) // network
+	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // keygen rm (swallowed)
+	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // SSH rm (swallowed)
+	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // DNS rm (swallowed)
+	m.AddResult("", "", fmt.Errorf("connection refused")) // network rm: real error
 	c := docker.NewClient(&m)
 	mgr := NewManager(c, DefaultRealm)
 
@@ -408,28 +398,13 @@ func TestCleanupMesh_NetworkError(t *testing.T) {
 	assert.Contains(t, err.Error(), "removing mesh network")
 }
 
-func TestCleanupMesh_RemoveContainerError(t *testing.T) {
-	var m mock.Executor
-	// keygen: not found
-	m.AddResult("", "Error\n", testutil.ExitCode1(t))
-	// SSH container: exists, rm -f fails
-	m.AddResult("[{}]\n", "", nil)
-	m.AddResult("", "Error: removal in progress\n", fmt.Errorf("exit status 1"))
-	c := docker.NewClient(&m)
-	mgr := NewManager(c, DefaultRealm)
-
-	err := mgr.CleanupMesh(t.Context())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "removing SSH container")
-}
-
 func TestCleanupMesh_VolumeError(t *testing.T) {
 	var m mock.Executor
-	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // keygen
-	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // SSH
-	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // DNS
-	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // network
-	m.AddResult("", "", fmt.Errorf("connection refused")) // volume
+	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // keygen (swallowed)
+	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // SSH (swallowed)
+	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // DNS (swallowed)
+	m.AddResult("", "Error\n", testutil.ExitCode1(t))     // network (swallowed)
+	m.AddResult("", "", fmt.Errorf("connection refused")) // volume: real error
 	c := docker.NewClient(&m)
 	mgr := NewManager(c, DefaultRealm)
 
@@ -1235,35 +1210,23 @@ func TestCustomRealm_EnsureSSH(t *testing.T) {
 
 func TestCustomRealm_CleanupMesh(t *testing.T) {
 	var m mock.Executor
-	// keygen container: not found
-	m.AddResult("", "Error\n", testutil.ExitCode1(t))
-	// SSH container: exists, rm -f
-	m.AddResult("[{}]\n", "", nil)
-	m.AddResult("myrealm-ssh\n", "", nil)
-	// DNS container: exists, rm -f
-	m.AddResult("[{}]\n", "", nil)
-	m.AddResult("myrealm-dns\n", "", nil)
-	// Network: exists, remove
-	m.AddResult("[{}]\n", "", nil)
-	m.AddResult("myrealm-mesh\n", "", nil)
-	// Volume: exists, remove
-	m.AddResult("[{}]\n", "", nil)
-	m.AddResult("myrealm-ssh-config\n", "", nil)
+	m.AddResult("", "Error\n", testutil.ExitCode1(t)) // keygen rm: not found (swallowed)
+	m.AddResult("myrealm-ssh\n", "", nil)             // SSH rm
+	m.AddResult("myrealm-dns\n", "", nil)             // DNS rm
+	m.AddResult("myrealm-mesh\n", "", nil)            // network rm
+	m.AddResult("myrealm-ssh-config\n", "", nil)      // volume rm
 	c := docker.NewClient(&m)
 	mgr := NewManager(c, "myrealm")
 
 	err := mgr.CleanupMesh(t.Context())
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"container", "inspect", "myrealm-ssh-keygen"}, m.Calls[0].Args)
-	assert.Equal(t, []string{"container", "inspect", "myrealm-ssh"}, m.Calls[1].Args)
-	assert.Equal(t, []string{"rm", "-f", "myrealm-ssh"}, m.Calls[2].Args)
-	assert.Equal(t, []string{"container", "inspect", "myrealm-dns"}, m.Calls[3].Args)
-	assert.Equal(t, []string{"rm", "-f", "myrealm-dns"}, m.Calls[4].Args)
-	assert.Equal(t, []string{"network", "inspect", "myrealm-mesh"}, m.Calls[5].Args)
-	assert.Equal(t, []string{"network", "rm", "myrealm-mesh"}, m.Calls[6].Args)
-	assert.Equal(t, []string{"volume", "inspect", "myrealm-ssh-config"}, m.Calls[7].Args)
-	assert.Equal(t, []string{"volume", "rm", "myrealm-ssh-config"}, m.Calls[8].Args)
+	require.Len(t, m.Calls, 5)
+	assert.Equal(t, []string{"rm", "-f", "myrealm-ssh-keygen"}, m.Calls[0].Args)
+	assert.Equal(t, []string{"rm", "-f", "myrealm-ssh"}, m.Calls[1].Args)
+	assert.Equal(t, []string{"rm", "-f", "myrealm-dns"}, m.Calls[2].Args)
+	assert.Equal(t, []string{"network", "rm", "myrealm-mesh"}, m.Calls[3].Args)
+	assert.Equal(t, []string{"volume", "rm", "myrealm-ssh-config"}, m.Calls[4].Args)
 }
 
 // dnsInspectJSON returns a mock docker inspect result for the DNS container on the mesh network.

--- a/pkg/mesh/mesh_test.go
+++ b/pkg/mesh/mesh_test.go
@@ -158,21 +158,24 @@ func TestDNSRecordLifecycle(t *testing.T) {
 		rec.AddResult("ssh-id\n", "", nil)                  // create SSH
 		rec.AddResult("sind-ssh\n", "", nil)                // start SSH
 
-		// AddDNSRecord "a": read → write → kill → start
+		// AddDNSRecord "a": read → write → inspect → kill → start
 		rec.AddResult(corefileTar(t, nil), "", nil)
 		rec.AddResult("", "", nil)
+		rec.AddResult(dnsInspectJSON(), "", nil)
 		rec.AddResult("sind-dns\n", "", nil)
 		rec.AddResult("sind-dns\n", "", nil)
 
-		// AddDNSRecord "b": read → write → kill → start
+		// AddDNSRecord "b": read → write → inspect → kill → start
 		rec.AddResult(corefileTar(t, []string{"172.18.0.2 a.test.sind.sind"}), "", nil)
 		rec.AddResult("", "", nil)
+		rec.AddResult(dnsInspectJSON(), "", nil)
 		rec.AddResult("sind-dns\n", "", nil)
 		rec.AddResult("sind-dns\n", "", nil)
 
-		// RemoveDNSRecord "a": read → write → kill → start
+		// RemoveDNSRecord "a": read → write → inspect → kill → start
 		rec.AddResult(corefileTar(t, []string{"172.18.0.2 a.test.sind.sind", "172.18.0.3 b.test.sind.sind"}), "", nil)
 		rec.AddResult("", "", nil)
+		rec.AddResult(dnsInspectJSON(), "", nil)
 		rec.AddResult("sind-dns\n", "", nil)
 		rec.AddResult("sind-dns\n", "", nil)
 
@@ -640,6 +643,8 @@ func TestAddDNSRecord_Empty(t *testing.T) {
 	m.AddResult(corefileTar(t, nil), "", nil)
 	// CopyToContainer → success
 	m.AddResult("", "", nil)
+	// InspectContainer → running
+	m.AddResult(dnsInspectJSON(), "", nil)
 	// KillContainer → success
 	m.AddResult("sind-dns\n", "", nil)
 	// StartContainer → success
@@ -650,15 +655,16 @@ func TestAddDNSRecord_Empty(t *testing.T) {
 	err := mgr.AddDNSRecord(t.Context(), "controller.dev.sind.sind", "172.18.0.2")
 	require.NoError(t, err)
 
-	require.Len(t, m.Calls, 4)
+	require.Len(t, m.Calls, 5)
 	// Verify read
 	assert.Equal(t, []string{"cp", string(DNSContainerName) + ":/Corefile", "-"}, m.Calls[0].Args)
 	// Verify written Corefile contains the record
 	corefile := extractTarFile(t, m.Calls[1].Stdin, "Corefile")
 	assert.Contains(t, corefile, "172.18.0.2 controller.dev.sind.sind")
-	// Verify restart
-	assert.Equal(t, []string{"kill", string(DNSContainerName)}, m.Calls[2].Args)
-	assert.Equal(t, []string{"start", string(DNSContainerName)}, m.Calls[3].Args)
+	// Verify state inspection + restart
+	assert.Equal(t, []string{"inspect", string(DNSContainerName)}, m.Calls[2].Args)
+	assert.Equal(t, []string{"kill", string(DNSContainerName)}, m.Calls[3].Args)
+	assert.Equal(t, []string{"start", string(DNSContainerName)}, m.Calls[4].Args)
 }
 
 func TestAddDNSRecord_Appends(t *testing.T) {
@@ -667,6 +673,7 @@ func TestAddDNSRecord_Appends(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, existing), "", nil)
 	m.AddResult("", "", nil)
+	m.AddResult(dnsInspectJSON(), "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	c := docker.NewClient(&m)
@@ -707,6 +714,7 @@ func TestAddDNSRecord_ReloadError(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, nil), "", nil)
 	m.AddResult("", "", nil)
+	m.AddResult(dnsInspectJSON(), "", nil)
 	m.AddResult("", "Error\n", fmt.Errorf("exit status 1"))
 	c := docker.NewClient(&m)
 	mgr := NewManager(c, DefaultRealm)
@@ -720,6 +728,7 @@ func TestAddDNSRecord_RestartError(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, nil), "", nil)               // read
 	m.AddResult("", "", nil)                                // write
+	m.AddResult(dnsInspectJSON(), "", nil)                  // inspect → running
 	m.AddResult("sind-dns\n", "", nil)                      // kill succeeds
 	m.AddResult("", "Error\n", fmt.Errorf("exit status 1")) // start fails
 	c := docker.NewClient(&m)
@@ -738,6 +747,7 @@ func TestAddDNSRecords(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, existing), "", nil) // read
 	m.AddResult("", "", nil)                       // write
+	m.AddResult(dnsInspectJSON(), "", nil)         // inspect → running
 	m.AddResult("sind-dns\n", "", nil)             // kill
 	m.AddResult("sind-dns\n", "", nil)             // start
 	c := docker.NewClient(&m)
@@ -749,8 +759,8 @@ func TestAddDNSRecords(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Only 4 docker calls total (read, write, kill, start).
-	require.Len(t, m.Calls, 4)
+	// Five docker calls total (read, write, inspect, kill, start).
+	require.Len(t, m.Calls, 5)
 
 	corefile := extractTarFile(t, m.Calls[1].Stdin, "Corefile")
 	assert.Contains(t, corefile, "172.18.0.2 controller.dev.sind.sind")
@@ -767,6 +777,7 @@ func TestAddDNSRecords_Dedup(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, existing), "", nil) // read
 	m.AddResult("", "", nil)                       // write
+	m.AddResult(dnsInspectJSON(), "", nil)         // inspect → running
 	m.AddResult("sind-dns\n", "", nil)             // kill
 	m.AddResult("sind-dns\n", "", nil)             // start
 	c := docker.NewClient(&m)
@@ -810,6 +821,7 @@ func TestRemoveDNSRecords(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, existing), "", nil) // read
 	m.AddResult("", "", nil)                       // write
+	m.AddResult(dnsInspectJSON(), "", nil)         // inspect → running
 	m.AddResult("sind-dns\n", "", nil)             // kill
 	m.AddResult("sind-dns\n", "", nil)             // start
 	c := docker.NewClient(&m)
@@ -821,8 +833,8 @@ func TestRemoveDNSRecords(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Only 4 docker calls total (read, write, kill, start).
-	require.Len(t, m.Calls, 4)
+	// Five docker calls total (read, write, inspect, kill, start).
+	require.Len(t, m.Calls, 5)
 
 	corefile := extractTarFile(t, m.Calls[1].Stdin, "Corefile")
 	assert.NotContains(t, corefile, "controller.dev.sind.sind")
@@ -861,6 +873,70 @@ func TestRemoveDNSRecords_Empty(t *testing.T) {
 	assert.Empty(t, m.Calls, "no docker calls for empty slice")
 }
 
+// TestRemoveDNSRecords_DNSStopped covers issue #52: deleting a cluster while
+// the sind-dns container is stopped must not fail. The Corefile is rewritten
+// and the running-state check short-circuits the kill/start reload.
+func TestRemoveDNSRecords_DNSStopped(t *testing.T) {
+	existing := []string{
+		"172.18.0.2 controller.dev.sind.sind",
+		"172.18.0.3 worker-0.dev.sind.sind",
+	}
+
+	var m mock.Executor
+	m.AddResult(corefileTar(t, existing), "", nil) // read
+	m.AddResult("", "", nil)                       // write
+	m.AddResult(dnsInspectExitedJSON(), "", nil)   // inspect → exited
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.RemoveDNSRecords(t.Context(), []string{"controller.dev.sind.sind"})
+	require.NoError(t, err)
+
+	// Only 3 docker calls (read, write, inspect) — no kill, no start.
+	require.Len(t, m.Calls, 3)
+	corefile := extractTarFile(t, m.Calls[1].Stdin, "Corefile")
+	assert.NotContains(t, corefile, "controller.dev.sind.sind")
+	assert.Contains(t, corefile, "172.18.0.3 worker-0.dev.sind.sind")
+}
+
+// TestRemoveDNSRecords_InspectError verifies that an inspect failure between
+// writing the Corefile and reloading DNS surfaces as a wrapped error.
+func TestRemoveDNSRecords_InspectError(t *testing.T) {
+	existing := []string{"172.18.0.2 controller.dev.sind.sind"}
+
+	var m mock.Executor
+	m.AddResult(corefileTar(t, existing), "", nil)
+	m.AddResult("", "", nil)
+	m.AddResult("", "Error\n", fmt.Errorf("exit status 1"))
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.RemoveDNSRecords(t.Context(), []string{"controller.dev.sind.sind"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "inspecting DNS container")
+}
+
+// TestAddDNSRecords_DNSStopped is the symmetric counterpart: adding records
+// while the DNS container is stopped writes the new Corefile but skips the
+// restart.
+func TestAddDNSRecords_DNSStopped(t *testing.T) {
+	var m mock.Executor
+	m.AddResult(corefileTar(t, nil), "", nil)    // read
+	m.AddResult("", "", nil)                     // write
+	m.AddResult(dnsInspectExitedJSON(), "", nil) // inspect → exited
+	c := docker.NewClient(&m)
+	mgr := NewManager(c, DefaultRealm)
+
+	err := mgr.AddDNSRecords(t.Context(), []DNSRecord{
+		{Hostname: "controller.dev.sind.sind", IP: "172.18.0.2"},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, m.Calls, 3)
+	corefile := extractTarFile(t, m.Calls[1].Stdin, "Corefile")
+	assert.Contains(t, corefile, "172.18.0.2 controller.dev.sind.sind")
+}
+
 // --- RemoveDNSRecord ---
 
 func TestRemoveDNSRecord(t *testing.T) {
@@ -872,6 +948,7 @@ func TestRemoveDNSRecord(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, existing), "", nil)
 	m.AddResult("", "", nil)
+	m.AddResult(dnsInspectJSON(), "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	c := docker.NewClient(&m)
@@ -891,6 +968,7 @@ func TestRemoveDNSRecord_LastEntry(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, existing), "", nil)
 	m.AddResult("", "", nil)
+	m.AddResult(dnsInspectJSON(), "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	c := docker.NewClient(&m)
@@ -912,6 +990,7 @@ func TestRemoveDNSRecord_NotFound(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, existing), "", nil)
 	m.AddResult("", "", nil)
+	m.AddResult(dnsInspectJSON(), "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	c := docker.NewClient(&m)
@@ -930,6 +1009,7 @@ func TestRemoveDNSRecord_ReloadError(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, existing), "", nil)
 	m.AddResult("", "", nil)
+	m.AddResult(dnsInspectJSON(), "", nil)
 	m.AddResult("", "Error\n", fmt.Errorf("exit status 1"))
 	c := docker.NewClient(&m)
 	mgr := NewManager(c, DefaultRealm)
@@ -949,6 +1029,7 @@ func TestRemoveDNSRecord_DuplicateHostnames(t *testing.T) {
 	var m mock.Executor
 	m.AddResult(corefileTar(t, existing), "", nil)
 	m.AddResult("", "", nil)
+	m.AddResult(dnsInspectJSON(), "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	m.AddResult("sind-dns\n", "", nil)
 	c := docker.NewClient(&m)
@@ -1188,6 +1269,11 @@ func TestCustomRealm_CleanupMesh(t *testing.T) {
 // dnsInspectJSON returns a mock docker inspect result for the DNS container on the mesh network.
 func dnsInspectJSON() string {
 	return `[{"Id":"dns123","Name":"/sind-dns","State":{"Status":"running"},"Config":{"Labels":{}},"NetworkSettings":{"Networks":{"sind-mesh":{"IPAddress":"10.0.0.2"}}}}]`
+}
+
+// dnsInspectExitedJSON returns a mock docker inspect result for a stopped DNS container.
+func dnsInspectExitedJSON() string {
+	return `[{"Id":"dns123","Name":"/sind-dns","State":{"Status":"exited"},"Config":{"Labels":{}},"NetworkSettings":{"Networks":{}}}]`
 }
 
 // --- GetInfo ---


### PR DESCRIPTION
Closes #52.

- `writeDNSEntries` skips the DNS-container reload when sind-dns is not
  running; the updated Corefile is loaded on next start
- `DeleteContainers` / `DeleteNetwork` / `DeleteVolumes` swallow
  IsNotFound with a warning; non-IsNotFound errors still abort
- `DeregisterMesh` wraps DNS-record and known_hosts removal with
  warn-and-continue
- mesh `CleanupMesh` helpers drop the redundant existence precheck and
  swallow IsNotFound from the actual remove, closing the TOCTOU window
- redundant `if err := DeregisterMesh(...); err != nil` checks in
  `deleteClusterResources` and `WorkerRemove` are removed